### PR TITLE
Fixed exception in case of key not exists

### DIFF
--- a/src/__/collections/where.php
+++ b/src/__/collections/where.php
@@ -28,7 +28,7 @@ function where(array $array = array(), array $key = array())
                     break;
                 }
             } else {
-                if ($v[$j] != $w) {
+                if (!isset($v[$j]) || $v[$j] != $w) {
                     $not = true;
                     break;
                 }


### PR DESCRIPTION
This is the case on which i caught exception. But now its fixed in this PR.
```php
// Arrange
$a = [
   ['name' => 'fred'],
   ['name' => 'maciej', 'age' => 16]
];

// Act
$x = __::where($a, ['age' => 16]);
```