### PR TITLE
Add 'randomize' function

### DIFF
--- a/src/__/arrays/randomize.php
+++ b/src/__/arrays/randomize.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace arrays;
+
+/**
+ * Shuffle an array
+ *
+ ** __::randomize([1, 2, 3]);
+ ** // → [2, 3, 1]
+ *
+ * @param array $array original array
+ *
+ * @return array
+ *
+ */
+function randomize(array $array = [])
+{
+    shuffle($array);
+
+    return $array;
+}

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -33,6 +33,7 @@ if (version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array flatten(array $input, bool $shallow = false) Flattens a multidimensional array. If you pass shallow, the array will only be flattened a single level.
  * @method static array patch(array $input, array $patches) Patches array with list of xpath-value pairs.
  * @method static array prepend(array $input, $item)
+ * @method static array randomize(array $input) Returns shuffled array.
  * @method static array range(int $startOrCount, int $stop = null, int $step = null) Returns an array of integers from start to stop (exclusive) by step.
  * @method static array repeat($input, int $times = 0) Returns an array of input repeated $times times.
  *


### PR DESCRIPTION
Added randomize (shuffle) function for arrays so we can shuffle arrays the **FUN**ctional way. 

```php
$a = [1, 2, 3, 4, 5];
$b = __::randomize($a);
// → [2, 3, 5, 1, 4]
```
Ideally we'd just call it `__::shuffle()` but the way the autoloader works makes this a no-go.