### PR TITLE
New: `identity`, `mapKeys`, `mapValues` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,41 @@ __::map([1, 2, 3], function($n) {
 // >> [3, 6, 9]
 ```
 
+##### [__::mapKeys](src/__/collections/mapKeys.php)
+Transforms the keys in a collection by running each key through the iterator
+```php
+__::mapKeys(['x' => 1], function($key, $value, $collection) {
+    return "{$key}_{$value}";
+});
+// >> ['x_1' => 1]
+ 
+__::mapKeys(['x' => 1], function($key) {
+    return strtoupper($key);
+});
+// >> ['X' => 3]
+ 
+__::mapKeys(['x' => 1])
+// >> ['x' => 1]
+
+```
+
+##### [__::mapValues](src/__/collections/mapValues.php)
+Transforms the values in a collection by running each value through the iterator
+```php
+__::mapValues(['x' => 1], function($value, $key, $collection) {
+    return "{$key}_{$value}";
+});
+// >> ['x' => 'x_1']
+ 
+__::mapValues(['x' => 1], function($value) {
+    return $value * 3;
+});
+// >> ['x' => 3]
+ 
+__::mapValues(['x' => 1])
+// >> ['x' => 1]
+```
+
 ##### [__::max](src/__/collections/max.php)
 Returns the maximum value from the collection. If passed an iterator, max will return max value returned by the iterator.
 ```php
@@ -335,6 +370,16 @@ __::isString('fred');
 ```
 
 ### Utilities
+
+#### [__::identity](src/__/utilities/identity.php)
+Returns the first argument it receives
+```php
+__::identity(1, 2, 3, 4)
+// >> 1
+ 
+__::identity()
+// >> null
+```
 
 ### Strings
 

--- a/src/__/collections/mapKeys.php
+++ b/src/__/collections/mapKeys.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace collections;
+
+/**
+ * Transforms the keys in a collection by running each key through the iterator
+ *
+ * @param array $array          array of values
+ * @param \Closure $closure     closure to map the keys
+ * @throws \Exception           if closure doesn't return a valid key that can be used in PHP array
+ *
+ * @return array
+ */
+function mapKeys(array $array, \Closure $closure = null)
+{
+    if (is_null($closure)) {
+        $closure = '__::identity';
+    }
+    $resultArray = [];
+    foreach ($array as $key => $value) {
+        $newKey = call_user_func_array($closure, array($key, $value, $array));
+        // key must be a number or string
+        if (!is_numeric($newKey) && !is_string($newKey)) {
+            throw new \Exception('closure must returns a number or string');
+        }
+
+        $resultArray[$newKey] = $value;
+    }
+    return $resultArray;
+}

--- a/src/__/collections/mapValues.php
+++ b/src/__/collections/mapValues.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace collections;
+
+/**
+ * Transforms the values in a collection by running each value through the iterator
+ *
+ * @param array $array          array of values
+ * @param \Closure $closure     closure to map the values
+ *
+ * @return array
+ */
+function mapValues(array $array, \Closure $closure = null)
+{
+    if (is_null($closure)) {
+        $closure = '__::identity';
+    }
+    $resultArray = [];
+    foreach ($array as $key => $value) {
+        $resultArray[$key] = call_user_func_array($closure, array($value, $key, $array));
+    }
+    return $resultArray;
+}

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -46,6 +46,8 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static bool hasKeys(array $input, array $keys, $strict = false) Returns if $input contains all requested $keys. If $strict is true it also checks if $input exclusively contains the given $keys.
  * @method static array|mixed last(array $input, int $count = null) Gets the last element of an array. Passing n returns the last n elements.
  * @method static array map(array $input, \Closure $func = null) Returns an array of values by mapping each in collection through the iterator.
+ * @method static array mapKeys(array $input, \Closure $func = null) Returns an array with keys being mapped through the iterator
+ * @method static array mapValues(array $input, \Closure $func = null) Returns an array with values being mapped through the iterator
  * @method static array max(array|\Traversable $input) Returns the maximum value from the collection. If passed an iterator, max will return max value returned by the iterator.
  * @method static array min(array|\Traversable $input) Returns the minimum value from the collection. If passed an iterator, min will return min value returned by the iterator.
  * @method static array pluck(array|object $input, string $key) Returns an array of values belonging to a given property of each item in a collection.
@@ -66,6 +68,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static bool isString($var)
  *
  * @method static int now()
+ * @method static mixed identity()
  *
  * @method static string camelCase(string $input)
  * @method static string capitalize(string $input)

--- a/src/__/utilities/identity.php
+++ b/src/__/utilities/identity.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace utilities;
+
+/**
+ * Returns the first argument it receives
+ *
+ * __::identity('arg1', 'arg2');
+ *      >> 'arg1'
+ *
+ * @return mixed
+ */
+function identity()
+{
+    $args = func_get_args();
+    return isset($args[0]) ? $args[0] : null;
+}

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -398,5 +398,134 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([$a[1]], $x3);
     }
 
-    // ...
+    public function testMapKeys()
+    {
+        // Arrange
+        $a = [
+            'name1' => [
+                'name' => 'Tuan',
+                'age' => 26
+            ],
+            'name2' => [
+                'name' => 'Nguyen',
+                'age' => '25'
+            ],
+        ];
+
+        // Act
+        $b = __::mapKeys($a, function($key) {
+            return strtoupper($key);
+        });
+
+        // Assert
+        $this->assertEquals([
+            'NAME1' => [
+                'name' => 'Tuan',
+                'age' => 26
+            ],
+            'NAME2' => [
+                'name' => 'Nguyen',
+                'age' => '25'
+            ],
+        ], $b);
+
+        // test with complicated closure
+        // Act
+        $b = __::mapKeys($a, function($key, $value, $collection) {
+            $size = count($collection);
+            return "{$key}_{$value['name']}_{$size}";
+        });
+
+        // Assert
+        $this->assertEquals([
+            'name1_Tuan_2' => [
+                'name' => 'Tuan',
+                'age' => 26
+            ],
+            'name2_Nguyen_2' => [
+                'name' => 'Nguyen',
+                'age' => '25'
+            ],
+        ], $b);
+
+        // test when closure is null, the returned array should have the same data with the original array
+        // Act
+        $b = __::mapKeys($a);
+
+        // Assert
+        $this->assertEquals($a, $b);
+    }
+
+    public function testMapKeysInvalidClosure()
+    {
+        if (method_exists($this, 'expectException')) {
+            // new phpunit
+            $this->expectException('\Exception', 'closure must returns a number or string');
+        } else {
+            // old phpunit
+            $this->setExpectedException('\Exception', 'closure must returns a number or string');
+        }
+
+        // Arrange
+        $a = ['x' => ['y' => 1]];
+
+        // Act
+        __::mapKeys($a, function($key) {
+            return ['key' => $key];
+        });
+    }
+
+    public function testMapValues()
+    {
+        // Arrange
+        $a = [
+            'name1' => [
+                'name' => 'Tuan',
+                'age' => 26
+            ],
+            'name2' => [
+                'name' => 'Nguyen',
+                'age' => '25'
+            ],
+        ];
+
+        // Act
+        $b = __::mapValues($a, function($value) {
+            return array_flip($value);
+        });
+
+        // Assert
+        $this->assertEquals([
+            'name1' => [
+                'Tuan' => 'name',
+                26 => 'age'
+            ],
+            'name2' => [
+                'Nguyen' => 'name',
+                25 => 'age'
+            ],
+        ], $b);
+
+        // test with complicated closure
+        // Act
+        $b = __::mapValues($a, function($value, $key, $collection) {
+            $size = count($collection);
+            return [
+                'subKey' => "{$value['age']}_{$key}_{$size}"
+            ];
+        });
+
+        // Assert
+        $this->assertEquals([
+            'name1' => ['subKey' => '26_name1_2'],
+            'name2' => ['subKey' => '25_name2_2'],
+        ], $b);
+
+        // test when closure is null, the returned array should have the same data with the original array
+        // Act
+        $b = __::mapValues($a);
+
+        // Assert
+        $this->assertEquals($a, $b);
+    }
 }

--- a/tests/utilities.php
+++ b/tests/utilities.php
@@ -11,4 +11,18 @@ class UtilitiesTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals(true, is_numeric($x));
     }
 
+    public function testIdentity()
+    {
+        // Act
+        $x = __::identity('arg 1', new DateTime());
+
+        // Assert
+        $this->assertEquals('arg 1', $x);
+
+        // Act
+        $x = __::identity();
+
+        // Assert
+        $this->assertEquals(null, $x);
+    }
 }


### PR DESCRIPTION
* `__::identity()`: returns the first argument it receives
* `__::mapKeys()`: transform the keys in a collection
* `__::mapValues()`: transform the values in a collection

`__::mapKeys()` and `__::mapValues()` can be extended to work with StdClass if required