### PR TITLE
New: add __::chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,19 @@ __::repeat('foo', 3);
 // >> ['foo', 'foo', 'foo']
 ```
 
-### Chaining
+### Sequences
 
-`coming soon...`
-
+#### [__::chain](src/__/sequences/chain.php)
+```php
+__::chain([1, 2, 3, 0, null])
+    ->compact()
+    ->prepend(4)
+    ->reduce(function($sum, $number) {
+        return $sum + $number;
+    }, 0)
+    ->value();
+// >> 10
+```
 
 ### Collections
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,8 @@
         <testsuite name="Strings Test Suite">
             <file>tests/strings.php</file>
         </testsuite>
+        <testsuite name="Sequences Test Suite">
+            <file>tests/sequences.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/__/arrays/prepend.php
+++ b/src/__/arrays/prepend.php
@@ -3,7 +3,7 @@
 namespace arrays;
 
 /**
- * prend item or value to an array
+ * prepend item or value to an array
  *
  ** __::prepend([1, 2, 3], 4);
  ** // → [4, 1, 2, 3]

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,11 +9,12 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [8]
- ** Collections                                  [15]
+ ** Collections                                 [15]
  ** Functions                                    [3]
  ** Objects                                      [7]
  ** Utilities                                    [0]
  ** Strings                                     [12]
+ ** Sequences                                    [1]
 
  ***************************************************
  * bottomline v0.1.0                               *
@@ -83,6 +84,8 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static string upperCase(string $input)
  * @method static string upperFirst(string $input)
  * @method static array words(string $input, string $pattern = null)
+ *
+ * @method static \BottomlineWrapper chain(mixed $input)
  */
 class __
 {
@@ -92,7 +95,8 @@ class __
         'functions',
         'objects',
         'utilities',
-        'strings'
+        'strings',
+        'sequences'
     ];
 
     private static $functions = [];

--- a/src/__/sequences/BottomlineWrapper.php
+++ b/src/__/sequences/BottomlineWrapper.php
@@ -1,0 +1,47 @@
+<?php
+
+class BottomlineWrapper
+{
+    /**
+     * @var mixed $value
+     */
+    private $value;
+
+    /**
+     * BottomlineWrapper constructor.
+     *
+     * @param mixed $value the value that is going to be chained
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * dynamically calls bottomline function, prepend the list of parameters with the current collection list
+     *
+     * @param string $functionName must be a valid bottomline function
+     * @param array $params
+     * @return $this
+     * @throws \Exception
+     */
+    public function __call($functionName, $params)
+    {
+        if (is_callable('__', $functionName)) {
+            $params = $params == null ? [] : $params;
+            $params = __::prepend($params, $this->value);
+            $this->value = call_user_func_array(array('__', $functionName), $params);
+            return $this;
+        } else {
+            throw new \Exception("Invalid function {$functionName}");
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    public function value()
+    {
+        return $this->value;
+    }
+}

--- a/src/__/sequences/chain.php
+++ b/src/__/sequences/chain.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace sequences;
+
+include_once 'BottomlineWrapper.php';
+
+/**
+ * returns a wrapper instance, allows the value to be passed through multiple bottomline functions
+ *
+ * __::chain([0, 1, 2, 3, null])
+ *   ->compact()
+ *   ->prepend(4)
+ *   ->value();
+ * >> [4, 1, 2, 3]
+ *
+ * @param mixed $initialValue
+ *
+ * @return mixed
+ *
+ */
+function chain($initialValue)
+{
+    return new \BottomlineWrapper($initialValue);
+}

--- a/tests/sequences.php
+++ b/tests/sequences.php
@@ -1,0 +1,58 @@
+<?php
+
+class SequencesTest extends \PHPUnit\Framework\TestCase
+{
+    // ...
+
+    public function testChainReturnsArray()
+    {
+        // Arrange
+        $collection = [0, 1, 2, 3, null];
+
+        // Act
+        $result = __::chain($collection)
+            ->compact()
+            ->prepend(4)
+            ->value();
+
+        // Assert
+        $this->assertEquals([4, 1, 2, 3], $result);
+    }
+
+    public function testChainReturnsNumber()
+    {
+        // Arrange
+        $collection = [0, 1, 2, 3, null];
+
+        // Act
+        $result = __::chain($collection)
+            ->compact()
+            ->prepend(4)
+            ->reduce(function($sum, $number) {
+                return $sum + $number;
+            }, 0)
+            ->value();
+
+        // Assert
+        $this->assertEquals(10, $result);
+    }
+
+    public function testChainWithError()
+    {
+        if (method_exists($this, 'expectException')) {
+            // new phpunit
+            $this->expectException('\Exception');
+        } else {
+            // old phpunit
+            $this->setExpectedException('\Exception');
+        }
+
+        // Arrange
+        $collection = [0, 1, 2, 3, null];
+
+        // Act
+        __::chain($collection)
+            ->randomFunc()
+            ->value();
+    }
+}


### PR DESCRIPTION
`__::chain()` function allows a value to be passed through multiple `bottomline` functions, and returns the final value.

can't really do a benchmark on this function, since it's just a wrapper for other functions