### PR TITLE
Fix "call to undefined function collections\set()" issue for unease().

### DIFF
--- a/src/__/collections/unease.php
+++ b/src/__/collections/unease.php
@@ -20,7 +20,7 @@ function unease(array $collection, $separator = '.')
 
     $map = [];
     foreach ($collection as $key => $value) {
-        $map = \collections\set(
+        $map = \__::set(
             $map,
             $nonDefaultSeparator ? \str_replace($separator, '.', $key) : $key,
             $value

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -21,6 +21,20 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['foo.bar' => $object, 'baz.0' => 'b', 'baz.1' => 'z'], $y);
     }
 
+    // running this one before __::set() tests also correct inner dependency autoload
+    public function testUnease()
+    {
+        // Arrange
+        $a = ['foo.bar' => 'ter', 'baz.0' => 'b', 'baz.1' => 'z'];
+
+        // Act
+        $x = __::unease($a);
+
+        // Assert
+        $this->assertEquals(2, count($x));
+        $this->assertEquals(['foo' => ['bar' => 'ter'], 'baz' => ['b', 'z']], $x);
+    }
+
     public function testFilter()
     {
         // Arrange
@@ -457,19 +471,6 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         // Act
         __::set($a, 'foo.bar.not_exist', 'baz', true);
-    }
-
-    public function testUnease()
-    {
-        // Arrange
-        $a = ['foo.bar' => 'ter', 'baz.0' => 'b', 'baz.1' => 'z'];
-
-        // Act
-        $x = __::unease($a);
-
-        // Assert
-        $this->assertEquals(2, count($x));
-        $this->assertEquals(['foo' => ['bar' => 'ter'], 'baz' => ['b', 'z']], $x);
     }
 
     public function testWhere()


### PR DESCRIPTION
Error occurred when `unease()` was called before the `set()` function
was ever used.

No special test case was written; existing function `testUnease()`
was moved before the `testSet()` to demonstrate the effect.