### PR TITLE
Fix collections\where() to filter out values with unset fields

### DIFF
--- a/src/__/collections/where.php
+++ b/src/__/collections/where.php
@@ -21,7 +21,7 @@ function where(array $array = [], array $cond = [])
 
     foreach ($array as $arrItem) {
         foreach ($cond as $condK => $condV) {
-            if (isset($arrItem[$condK]) && $arrItem[$condK] !== $condV) {
+            if (!isset($arrItem[$condK]) || $arrItem[$condK] !== $condV) {
                 continue 2;
             }
         }

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -478,18 +478,21 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         // Arrange
         $a = [
             ['name' => 'fred',   'age' => 32],
-            ['name' => 'maciej', 'age' => 16]
+            ['name' => 'maciej', 'age' => 16],
+            ['a' => 'b', 'c' => 'd']
         ];
 
         // Act
         $x = __::where($a, ['age' => 16]);
         $x2 = __::where($a, ['age' => 16, 'name' => 'fred']);
         $x3 = __::where($a, ['name' => 'maciej', 'age' => 16]);
+        $x4 = __::where($a, ['name' => 'unknown']);
 
         // Assert
         $this->assertEquals([$a[1]], $x);
         $this->assertEquals([], $x2);
         $this->assertEquals([$a[1]], $x3);
+        $this->assertEquals([], $x4);
     }
 
     public function testMapKeys()


### PR DESCRIPTION
To reproduce a bug, pass into `where` condition a structure with keys not present in array elements.

Example:
```php
$result = __::where([['a' => 'b'], ['c' => 'd']], ['e' => 'f']);

// $result now contains: [['a' => 'b'], ['c' => 'd']] 
```