### PR TITLE
Make collection functions applicable to both arrays and objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Added `__::isCollection`
 * Added `__::has`
 * Make `__::pick()`, `__::set()` work on both arrays and objects
+* Make `__::set()` to return a copy of the collection (do not mutate)
+* Remove `$strict` optional parameter of `__::set()`: it always create or override portion of path
 
 ## <sub>v0.1.0</sub>
 #### _Sept 24, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.9...0.1.0) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,30 +3,30 @@
 ## <sub>unreleased</sub>
 #### [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.0...master) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/master/README.md)
 
-* Added `__.pick`
-* Added `__.groupBy`
-* Added `__.reduce`
-* Added `__.mapKeys`
-* Added `__.mapValues`
-* Added `__.identity`
-* Added `__.isCollection`
-* Make `__.pick()`, `__.set()` work on both arrays and objects
+* Added `__::pick`
+* Added `__::groupBy`
+* Added `__::reduce`
+* Added `__::mapKeys`
+* Added `__::mapValues`
+* Added `__::identity`
+* Added `__::isCollection`
+* Make `__::pick()`, `__::set()` work on both arrays and objects
 
 ## <sub>v0.1.0</sub>
 #### _Sept 24, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.9...0.1.0) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.0/README.md)
 
-* Added `__.camelCase`
-* Added `__.capitalize`
-* Added `__.kebabCase`
-* Added `__.lowerCase`
-* Added `__.lowerFirst`
-* Added `__.snakeCase`
-* Added `__.startCase`
-* Added `__.toLower`
-* Added `__.toUpper`
-* Added `__.upperCase`
-* Added `__.upperFirst`
-* Added `__.words`
+* Added `__::camelCase`
+* Added `__::capitalize`
+* Added `__::kebabCase`
+* Added `__::lowerCase`
+* Added `__::lowerFirst`
+* Added `__::snakeCase`
+* Added `__::startCase`
+* Added `__::toLower`
+* Added `__::toUpper`
+* Added `__::upperCase`
+* Added `__::upperFirst`
+* Added `__::words`
 
 ## <sub>v0.0.9</sub>
 #### _Jan 5, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.8...0.0.9) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.0.9/README.md)
@@ -37,25 +37,25 @@
 ## <sub>v0.0.8</sub>
 #### _Jan 3, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.7...0.0.8) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.0.8/README.md)
 
-* Added `__.chunk`
-* Added `__.randomize`
-* Added `__.ease`
-* Added `__.hasKeys`
-* Added `__.set`
-* Added `__.unease`
+* Added `__::chunk`
+* Added `__::randomize`
+* Added `__::ease`
+* Added `__::hasKeys`
+* Added `__::set`
+* Added `__::unease`
 * Simplified “Array” methods
 * Enhanced PHPDoc
 
 ## <sub>v0.0.7</sub>
 #### _Dec 1, 2014_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.6...0.0.7) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.0.7/README.md)
 
-* Added `__.now`
+* Added `__::now`
 * Documentation improvements
 
 ## <sub>v0.0.6</sub>
 #### _Aug 7, 2014_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.5...0.0.6) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.0.6/README.md)
 
-* Added `__.patch`
+* Added `__::patch`
 * Added benchmark with other libraries
 * Added Composer installation instructions
 * Added PHPDoc on each function
@@ -63,24 +63,24 @@
 ## <sub>v0.0.5</sub>
 #### _Jul 27, 2014_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.4...0.0.5) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.0.5/README.md)
 
-* Added `__.append`
-* Added `__.flatten`
-* Added `__.prepend`
-* Added `__.slug`
-* Added `__.truncate`
-* Added `__.urlify`
-* Added `__.first`
-* Added `__.last`
-* Added `__.get`
-* Added `__.pluck`
-* Added `__.where`
-* Added `__.isArray`
-* Added `__.isEmail`
-* Added `__.isFunction`
-* Added `__.isNull`
-* Added `__.isNumber`
-* Added `__.isObject`
-* Added `__.isString`
+* Added `__::append`
+* Added `__::flatten`
+* Added `__::prepend`
+* Added `__::slug`
+* Added `__::truncate`
+* Added `__::urlify`
+* Added `__::first`
+* Added `__::last`
+* Added `__::get`
+* Added `__::pluck`
+* Added `__::where`
+* Added `__::isArray`
+* Added `__::isEmail`
+* Added `__::isFunction`
+* Added `__::isNull`
+* Added `__::isNumber`
+* Added `__::isObject`
+* Added `__::isString`
 * Added benchmark with other libraries
 * Added Composer installation instructions
 * Added PHPDoc on each function
@@ -88,20 +88,20 @@
 ## <sub>v0.0.4</sub>
 #### _Jun 23, 2014_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/v0.0.3...0.0.4) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.0.4/README.md)
 
-* Added `__.compact`
-* Added `__.range`
-* Added `__.repeat`
-* Added `__.filter`
-* Added `__.map`
-* Added `__.max`
-* Added `__.min`
-* Added internal function autoloader `__.load`
+* Added `__::compact`
+* Added `__::range`
+* Added `__::repeat`
+* Added `__::filter`
+* Added `__::map`
+* Added `__::max`
+* Added `__::min`
+* Added internal function autoloader `__::load`
 * Added unit tests (PHPUnit)
 
 ## <sub>v0.0.3</sub>
 #### _Jan 17, 2014_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/v0.0.2...v0.0.3) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/v0.0.3/README.md)
 
-* Added `__.each`
+* Added `__::each`
 
 ## <sub>v0.0.2</sub>
 #### _Jan 6, 2014_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/v0.0.1...v0.0.2) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/v0.0.2/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added `__::isCollection`
 * Added `__::has`
 * Added `__::split`
+* Added `__::drop`
 * Make `__::pick()`, `__::set()` work on both arrays and objects
 * Make `__::set()` to return a copy of the collection (do not mutate)
 * Remove `$strict` optional parameter of `__::set()`: it always create or override portion of path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added `__::mapValues`
 * Added `__::identity`
 * Added `__::isCollection`
+* Added `__::has`
 * Make `__::pick()`, `__::set()` work on both arrays and objects
 
 ## <sub>v0.1.0</sub>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,9 @@
 * Added `__::drop`
 * Added `__::isEmpty`
 * Added `__::doForEach`
-* Made `__::pick()`, `__::set()` work on both arrays and objects
+* Made `__::pick()`, `__::set()`, `__::map()` and `__::hasKeys()` to work on both arrays and objects
 * Made `__::set()` to return a copy of the collection (do not mutate)
 * Removed `$strict` optional parameter of `__::set()`: it always create or override portion of path
-* Allowed `__::map()` to work on objects
 
 ## <sub>v0.1.0</sub>
 #### _Sept 24, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.9...0.1.0) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Added `__::has`
 * Added `__::split`
 * Added `__::drop`
+* Added `__::isEmpty`
 * Make `__::pick()`, `__::set()` work on both arrays and objects
 * Make `__::set()` to return a copy of the collection (do not mutate)
 * Remove `$strict` optional parameter of `__::set()`: it always create or override portion of path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Added `__.mapKeys`
 * Added `__.mapValues`
 * Added `__.identity`
+* Added `__.isCollection`
+* Make `__.pick()`, `__.set()` work on both arrays and objects
 
 ## <sub>v0.1.0</sub>
 #### _Sept 24, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.9...0.1.0) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.0/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Added `__::doForEach`
 * Added `__::every`
 * Made `__::pick()`, `__::set()`, `__::map()` and `__::hasKeys()` to work on both arrays and objects
+* Made `__::hasKeys()` to work with paths
 * Made `__::set()` to return a copy of the collection (do not mutate)
 * Removed `$strict` optional parameter of `__::set()`: it always create or override portion of path
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Added `__::drop`
 * Added `__::isEmpty`
 * Added `__::doForEach`
+* Added `__::every`
 * Made `__::pick()`, `__::set()`, `__::map()` and `__::hasKeys()` to work on both arrays and objects
 * Made `__::set()` to return a copy of the collection (do not mutate)
 * Removed `$strict` optional parameter of `__::set()`: it always create or override portion of path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added `__::split`
 * Added `__::drop`
 * Added `__::isEmpty`
+* Added `__::doForEach`
 * Made `__::pick()`, `__::set()` work on both arrays and objects
 * Made `__::set()` to return a copy of the collection (do not mutate)
 * Removed `$strict` optional parameter of `__::set()`: it always create or override portion of path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added `__::identity`
 * Added `__::isCollection`
 * Added `__::has`
+* Added `__::split`
 * Make `__::pick()`, `__::set()` work on both arrays and objects
 * Make `__::set()` to return a copy of the collection (do not mutate)
 * Remove `$strict` optional parameter of `__::set()`: it always create or override portion of path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@
 * Added `__::split`
 * Added `__::drop`
 * Added `__::isEmpty`
-* Make `__::pick()`, `__::set()` work on both arrays and objects
-* Make `__::set()` to return a copy of the collection (do not mutate)
-* Remove `$strict` optional parameter of `__::set()`: it always create or override portion of path
+* Made `__::pick()`, `__::set()` work on both arrays and objects
+* Made `__::set()` to return a copy of the collection (do not mutate)
+* Removed `$strict` optional parameter of `__::set()`: it always create or override portion of path
+* Allowed `__::map()` to work on objects
 
 ## <sub>v0.1.0</sub>
 #### _Sept 24, 2017_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.0.9...0.1.0) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.0/README.md)

--- a/README.md
+++ b/README.md
@@ -460,6 +460,13 @@ __::snakeCase('Foo Bar');
 // >> 'foo_bar'
 ```
 
+##### [__::split](src/__/strings/split.php)
+Split a string by string.
+```php
+__::split('github.com', '.');
+// >> ['github', 'com']
+```
+
 ##### [__::startCase](src/__/strings/startCase.php)
 ```php
 __::startCase('fooBar');

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ __::reduce([1, 2], function ($sum, $number) {
 ```
 
 ##### [__::set](src/__/collections/set.php)
-Set item of an array by index to given value, accepting nested index
+Return a new collection with the item set at index to given value. Index can be a path.
 ```php
 __::set(['foo' => ['bar' => 'ter']], 'foo.baz.ber', 'fer');
 // >> ['foo' => ['bar' => 'ter', 'baz' => ['ber' => 'fer']]]

--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ __::hasKeys(['foo' => 'bar', 'foz' => 'baz'], ['foo', 'foz']);
 // >> true
 ```
 
+##### [__::isEmpty](src/__/collections/isEmpty.php)
+Check if value is an empty array or object.
+```php
+__::isEmpty([]);
+// >> true
+__::isEmpty(new stdClass());
+// >> true
+```
+
 ##### [__::last](src/__/collections/last.php)
 Gets the last element of an array. Passing n returns the last n elements.
 ```php

--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ __::doForEach(
 ##### [__::every](src/__/collections/every.php)
 Checks if predicate returns truthy for all elements of collection.
 ```php
-__::every([true, 1, null, 'yes'], 'is_bool')
+__::every([true, 1, null, 'yes'], function ($v) { return is_bool($v); })
 // >> false
-__::every([true, false], 'is_bool')
+__::every([true, false], function ($v) { return is_bool($v); })
 // >> true
 ```
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ __::first([1, 2, 3, 4, 5], 2);
 // >> [1, 2]
 ```
 
+##### [__::doForEach](src/__/collections/forEach.php)
+Iterate over elements of the collection and invokes iteratee for each element.
+```php
+__::doForEach(
+    [1, 2, 3],
+    function ($n) {
+        print_r($n)
+    }
+);
+// >> (Side effect: print numbers)
+```
+
 ##### [__::get](src/__/collections/get.php)
 Get item of an array by index, aceepting nested index
 ```php

--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ __::doForEach(
 // >> (Side effect: print numbers)
 ```
 
+##### [__::every](src/__/collections/every.php)
+Checks if predicate returns truthy for all elements of collection.
+```php
+__::every([true, 1, null, 'yes'], 'is_bool')
+// >> false
+__::every([true, false], 'is_bool')
+// >> true
+```
+
 ##### [__::get](src/__/collections/get.php)
 Get item of an array by index, aceepting nested index
 ```php

--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ __::mapKeys(['x' => 1], function($key, $value, $collection) {
     return "{$key}_{$value}";
 });
 // >> ['x_1' => 1]
- 
+
 __::mapKeys(['x' => 1], function($key) {
     return strtoupper($key);
 });
 // >> ['X' => 3]
- 
+
 __::mapKeys(['x' => 1])
 // >> ['x' => 1]
 
@@ -252,12 +252,12 @@ __::mapValues(['x' => 1], function($value, $key, $collection) {
     return "{$key}_{$value}";
 });
 // >> ['x' => 'x_1']
- 
+
 __::mapValues(['x' => 1], function($value) {
     return $value * 3;
 });
 // >> ['x' => 3]
- 
+
 __::mapValues(['x' => 1])
 // >> ['x' => 1]
 ```
@@ -396,6 +396,13 @@ __::isString('fred');
 // >> true
 ```
 
+##### [__::isCollection](src/__/objects/isCollection.php)
+Returns true if the argument is a collection (that is an array or object).
+```php
+__::isCollection([1, 2, 3]);
+// >> true
+```
+
 ### Utilities
 
 #### [__::identity](src/__/utilities/identity.php)
@@ -403,7 +410,7 @@ Returns the first argument it receives
 ```php
 __::identity(1, 2, 3, 4)
 // >> 1
- 
+
 __::identity()
 // >> null
 ```

--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ __::groupBy($a, 'continent');
 // ]
 ```
 
+##### [__::has](src/__/collections/has.php)
+Returns true if the collection contains the requested key.
+```php
+__::has(['foo' => 'bar', 'foz' => 'baz'], 'foo');
+// >> true
+```
+
 ##### [__::hasKeys](src/__/collections/hasKeys.php)
 Returns if $input contains all requested $keys. If $strict is true it also checks if $input exclusively contains the given $keys.
 ```php

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ __::compact([0, 1, false, 2, '', 3]);
 ##### [__::drop](src/__/arrays/drop.php)
 Creates a slice of array with n elements dropped from the beginning.
 ```php
-__::drop(1, 2, 3], 2);
+__::drop([1, 2, 3], 2);
 // >> [3]
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ __::compact([0, 1, false, 2, '', 3]);
 // >> [1, 2, 3]
 ```
 
+##### [__::drop](src/__/arrays/drop.php)
+Creates a slice of array with n elements dropped from the beginning.
+```php
+__::drop(1, 2, 3], 2);
+// >> [3]
+```
+
 ##### [__::flatten](src/__/arrays/flatten.php)
 Flattens a multidimensional array. If you pass shallow, the array will only be flattened a single level.
 ```php

--- a/src/__/arrays/drop.php
+++ b/src/__/arrays/drop.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace arrays;
+
+/**
+ * Creates a slice of array with n elements dropped from the beginning.
+ *
+ ** __::drop([0, 1, 3], 2);
+ ** // → [3]
+ *
+ * @param array $input The array to query.
+ * @param int $number The number of elements to drop.
+ *
+ * @return array
+ *
+ */
+function drop(array $input, $number = 1)
+{
+    return array_slice($input, $number);
+}

--- a/src/__/collections/doForEach.php
+++ b/src/__/collections/doForEach.php
@@ -20,6 +20,8 @@ namespace collections;
 function doForEach($collection, \Closure $iteratee)
 {
     foreach ($collection as $key => $value) {
-        $iteratee($value, $key, $collection);
+        if ($iteratee($value, $key, $collection) === false) {
+            break;
+        }
     }
 }

--- a/src/__/collections/doForEach.php
+++ b/src/__/collections/doForEach.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace collections;
+
+/**
+ * Iterate over elements of the collection and invokes iteratee for each element.
+ *
+ * The iteratee is invoked with three arguments: (value, index|key, collection).
+ * Iteratee functions may exit iteration early by explicitly returning false.
+ *
+ ** __::doForEach([1, 2, 3], function ($value) { print_r($value) });
+ ** // → (Side effect: print 1, 2, 3)
+ *
+ * @param array|object $collection The collection to iterate over.
+ * @param Closure $iterate The function to call for each value.
+ *
+ * @return null
+ *
+ */
+function doForEach($collection, \Closure $iteratee)
+{
+    foreach ($collection as $key => $value) {
+        $iteratee($value, $key, $collection);
+    }
+}

--- a/src/__/collections/every.php
+++ b/src/__/collections/every.php
@@ -8,7 +8,7 @@ namespace collections;
  * Iteration is stopped once predicate returns falsey.
  * The predicate is invoked with three arguments: (value, index|key, collection).
  *
- ** __::every([1, 3, 4], 'is_int');
+ ** __::every([1, 3, 4], function ($v) { return is_int($v); });
  ** // → true
  *
  * @param array|object $collection The collection to iterate over.

--- a/src/__/collections/every.php
+++ b/src/__/collections/every.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace collections;
+
+/**
+ * Checks if predicate returns truthy for all elements of collection.
+ *
+ * Iteration is stopped once predicate returns falsey.
+ * The predicate is invoked with three arguments: (value, index|key, collection).
+ *
+ ** __::every([1, 3, 4], 'is_int');
+ ** // → true
+ *
+ * @param array|object $collection The collection to iterate over.
+ * @param Closure $iterate The function to call for each value.
+ *
+ * @return bool
+ *
+ */
+function every($collection, $iteratee)
+{
+    $truthy = true;
+    // We could use __::reduce(), but it won't allow us to return preminarily.
+    \__::doForEach(
+        $collection,
+        function ($value, $key, $collection) use(&$truthy, $iteratee) {
+            $truthy = $truthy && $iteratee($value, $key, $collection);
+            if (!$truthy) return false;
+        }
+    );
+    return $truthy;
+}

--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -24,7 +24,7 @@ function get($collection, $path, $default = null)
         return $collection[$path];
     }
 
-    foreach (\explode('.', $path) as $segment) {
+    foreach (\__::split($path, '.') as $segment) {
         if (\is_object($collection)) {
             if (isset($collection->{$segment})) {
                 $collection = $collection->{$segment};

--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -26,12 +26,15 @@ function get($collection, $path, $default = null)
             if (isset($collection->{$segment})) {
                 $collection = $collection->{$segment};
             } else {
+                // TODO Remove Closure option: what is the point if it has no parameter:
+                // it will always yielf the same value? KISS.
                 return $default && $default instanceof \Closure ? $default() : $default;
             }
         } else {
             if (isset($collection[$segment])) {
                 $collection = $collection[$segment];
             } else {
+                // TODO Same as above on Closure.
                 return $default && $default instanceof \Closure ? $default() : $default;
             }
         }

--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -3,25 +3,25 @@
 namespace collections;
 
 /**
- * get item of an array by index , aceepting nested index
+ * get item of an array by index, accepting path (nested index).
  *
  ** __::get(['foo' => ['bar' => 'ter']], 'foo.bar');
  ** // → 'ter'
  *
- * @param array|object   $collection array of values
- * @param string         $key        array key or object attribute
- * @param \Closure|mixed $default    default value to return if index not exist
+ * @param array|object $collection array of values
+ * @param string $path array key or object attribute
+ * @param \Closure|mixed $default default value to return if index not exist
  *
  * @return array|mixed|null
  *
  */
-function get($collection, $key, $default = null)
+function get($collection, $path, $default = null)
 {
-    if (\is_array($collection) && isset($collection[$key])) {
-        return $collection[$key];
+    if (\is_array($collection) && isset($collection[$path])) {
+        return $collection[$path];
     }
 
-    foreach (\explode('.', $key) as $segment) {
+    foreach (\explode('.', $path) as $segment) {
         if (\is_object($collection)) {
             if (isset($collection->{$segment})) {
                 $collection = $collection->{$segment};

--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -17,6 +17,9 @@ namespace collections;
  */
 function get($collection, $path, $default = null)
 {
+    // TODO Make the algorithm recursive.
+    // TODO Factorize between object and array access (use a $getter function,
+    // as the $setter in __::set()).
     if (\is_array($collection) && isset($collection[$path])) {
         return $collection[$path];
     }

--- a/src/__/collections/has.php
+++ b/src/__/collections/has.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace collections;
+
+/**
+ * Return true if $collection contains the requested $key.
+ *
+ * In constrast to isset(), __::has() returns true if the key exists but is null.
+ *
+ ** __::hasKeys(['foo' => 'bar', 'foz' => 'baz'], 'foo');
+ ** // → true
+ *
+ ** __::hasKeys((object) ['foo' => 'bar', 'foz' => 'baz'], 'bar');
+ ** // → false
+ *
+ * @param array $collection of key values pairs
+ * @param string|integer $key key to look for
+ *
+ * @return boolean
+ *
+ */
+function has($collection, $key)
+{
+    // TODO Support path lookup.
+    $has = \__::isObject($collection) ? 'property_exists' : 'array_key_exists';
+    $args = \__::isObject($collection) ? [$collection, $key] : [$key, $collection];
+
+    return call_user_func_array($has, $args);
+}

--- a/src/__/collections/has.php
+++ b/src/__/collections/has.php
@@ -13,17 +13,22 @@ namespace collections;
  ** __::hasKeys((object) ['foo' => 'bar', 'foz' => 'baz'], 'bar');
  ** // → false
  *
- * @param array $collection of key values pairs
- * @param string|integer $key key to look for
+ * @param array|object $collection of key values pairs
+ * @param string|integer $path Path to look for.
  *
  * @return boolean
  *
  */
-function has($collection, $key)
+function has($collection, $path)
 {
-    // TODO Support path lookup.
-    $has = \__::isObject($collection) ? 'property_exists' : 'array_key_exists';
-    $args = \__::isObject($collection) ? [$collection, $key] : [$key, $collection];
+    // TODO Factorize path mavigation/enumeration with set and get.
+    $portions = \__::split($path, '.', 2);
+    $key  = $portions[0];
 
-    return call_user_func_array($has, $args);
+    if (\count($portions) === 1) {
+        $has = \__::isObject($collection) ? 'property_exists' : 'array_key_exists';
+        $args = \__::isObject($collection) ? [$collection, $key] : [$key, $collection];
+        return call_user_func_array($has, $args);
+    }
+    return has(\__::get($collection, $key), $portions[1]);
 }

--- a/src/__/collections/hasKeys.php
+++ b/src/__/collections/hasKeys.php
@@ -8,19 +8,19 @@ namespace collections;
  ** __::hasKeys(['foo' => 'bar', 'foz' => 'baz'], ['foo', 'foz']);
  ** // → true
  *
- * @param array   $collection of key values pairs
+ * @param array|object $collection of key values pairs
  * @param array   $keys       collection of keys to look for
  * @param boolean $strict     to exclusively check
  *
  * @return boolean
  *
  */
-function hasKeys(array $collection = [], array $keys = [], $strict = false)
+function hasKeys($collection = [], array $keys = [], $strict = false)
 {
     $keyCount = \count($keys);
     if ($strict && \count($collection) !== $keyCount) {
         return false;
     }
-
-    return \count(\array_intersect($keys, \array_keys($collection))) === $keyCount;
+    
+    return \count(\array_intersect($keys, \array_keys((array) $collection))) === $keyCount;
 }

--- a/src/__/collections/hasKeys.php
+++ b/src/__/collections/hasKeys.php
@@ -21,6 +21,10 @@ function hasKeys($collection = [], array $keys = [], $strict = false)
     if ($strict && \count($collection) !== $keyCount) {
         return false;
     }
-    
-    return \count(\array_intersect($keys, \array_keys((array) $collection))) === $keyCount;
+    return \__::every(
+        \__::map($keys, function ($key) use($collection) {
+            return \__::has($collection, $key);
+        }),
+        function ($v) { return $v === true; }
+    );
 }

--- a/src/__/collections/isEmpty.php
+++ b/src/__/collections/isEmpty.php
@@ -5,6 +5,8 @@ namespace collections;
 /**
  * Check if value is an empty array or object.
  *
+ * We consider any non enumerable as empty.
+ *
  ** __::isEmpty([]);
  ** // → true
  *
@@ -15,5 +17,6 @@ namespace collections;
  */
 function isEmpty($value)
 {
-    return count((array) $value) === 0;
+    // TODO Create and use our own __::size(). (Manage object, etc.).
+    return (!\__::isArray($value) && !\__::isObject($value)) || count((array) $value) === 0;
 }

--- a/src/__/collections/isEmpty.php
+++ b/src/__/collections/isEmpty.php
@@ -15,5 +15,5 @@ namespace collections;
  */
 function isEmpty($value)
 {
-    return empty($value);
+    return count((array) $value) === 0;
 }

--- a/src/__/collections/isEmpty.php
+++ b/src/__/collections/isEmpty.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace collections;
+
+/**
+ * Check if value is an empty array or object.
+ *
+ ** __::isEmpty([]);
+ ** // → true
+ *
+ * @param $value The value to check for emptiness.
+ *
+ * @return boolean
+ *
+ */
+function isEmpty($value)
+{
+    return empty($value);
+}

--- a/src/__/collections/map.php
+++ b/src/__/collections/map.php
@@ -15,9 +15,9 @@ namespace collections;
  */
 function map($collection, \Closure $iteratee)
 {
-    //
-    // foreach ($collection as $key => $value) {
-    //     $accumulator = $iteratee($accumulator, $value, $key, $collection);
-    // }
-    return \array_map($iteratee, (array) $collection);
+    $result = [];
+    foreach ($collection as $key => $value) {
+        $result[] = $iteratee($value, $key, $collection);
+    }
+    return $result;
 }

--- a/src/__/collections/map.php
+++ b/src/__/collections/map.php
@@ -3,15 +3,21 @@
 namespace collections;
 
 /**
- * Returns an array of values by mapping each in collection through the iterator.
+ * Returns an array of values by mapping each in collection through the iteratee.
  *
- * @param array    $array array of values
- * @param \Closure $closure closure to mapp based on
+ * The iteratee is invoked with three arguments: (value, index|key, collection).
+ *
+ * @param array|object $collection The collection of values to map over.
+ * @param Closure $iteratee The function to apply on each value.
  *
  * @return array
  *
  */
-function map(array $array, \Closure $closure)
+function map($collection, \Closure $iteratee)
 {
-    return \array_map($closure, $array);
+    //
+    // foreach ($collection as $key => $value) {
+    //     $accumulator = $iteratee($accumulator, $value, $key, $collection);
+    // }
+    return \array_map($iteratee, (array) $collection);
 }

--- a/src/__/collections/map.php
+++ b/src/__/collections/map.php
@@ -16,8 +16,11 @@ namespace collections;
 function map($collection, \Closure $iteratee)
 {
     $result = [];
-    foreach ($collection as $key => $value) {
-        $result[] = $iteratee($value, $key, $collection);
-    }
+    \__::doForEach(
+        $collection,
+        function ($value, $key, $collection) use(&$result, $iteratee) {
+            $result[] = $iteratee($value, $key, $collection);
+        }
+    );
     return $result;
 }

--- a/src/__/collections/pick.php
+++ b/src/__/collections/pick.php
@@ -17,7 +17,10 @@ namespace collections;
  */
 function pick($collection = [], array $paths = [], $default = null)
 {
+    if (!\__::isArray($collection) && !\__::isObject($collection)) {
+        throw new \InvalidArgumentException('Expected collection to be an array or object');
+    }
     return \__::reduce($paths, function ($results, $path) use ($collection, $default) {
         return \__::set($results, $path, \__::get($collection, $path, $default));
-    }, []);
+    }, \__::isObject($collection) ? new \stdClass() : []);
 }

--- a/src/__/collections/pick.php
+++ b/src/__/collections/pick.php
@@ -19,11 +19,7 @@ function pick(array $array = [], array $paths = [], $default = null)
 {
     $result = [];
     foreach ($paths as $path) {
-        if (strpos($path, '.') === false) {
-            $result[$path] = isset($array[$path]) ? $array[$path] : $default;
-        } else {
-            $result = \__::set($result, $path, \__::get($array, $path, $default));
-        }
+        $result = \__::set($result, $path, \__::get($array, $path, $default));
     }
     return $result;
 }

--- a/src/__/collections/pick.php
+++ b/src/__/collections/pick.php
@@ -17,9 +17,7 @@ namespace collections;
  */
 function pick(array $array = [], array $paths = [], $default = null)
 {
-    $result = [];
-    foreach ($paths as $path) {
-        $result = \__::set($result, $path, \__::get($array, $path, $default));
-    }
-    return $result;
+    return \__::reduce($paths, function ($results, $path) use ($array, $default) {
+        return \__::set($results, $path, \__::get($array, $path, $default));
+    }, []);
 }

--- a/src/__/collections/pick.php
+++ b/src/__/collections/pick.php
@@ -10,14 +10,14 @@ namespace collections;
  ** __::pick(['a' => 1, 'b' => ['c' => 3, 'd' => 4]], ['a', 'b.d']);
  ** // → ['a' => 1, 'b' => ['d' => 4]]
  *
- * @param array $collection array|object $collection The collection to iterate over.
+ * @param array|object $collection The collection to iterate over.
  * @param array $paths array paths to pick
  *
  * @return array
  */
 function pick($collection = [], array $paths = [], $default = null)
 {
-    if (!\__::isArray($collection) && !\__::isObject($collection)) {
+    if (!\__::isCollection($collection)) {
         throw new \InvalidArgumentException('Expected collection to be an array or object');
     }
     return \__::reduce($paths, function ($results, $path) use ($collection, $default) {

--- a/src/__/collections/pick.php
+++ b/src/__/collections/pick.php
@@ -17,9 +17,6 @@ namespace collections;
  */
 function pick($collection = [], array $paths = [], $default = null)
 {
-    if (!\__::isCollection($collection)) {
-        throw new \InvalidArgumentException('Expected collection to be an array or object');
-    }
     return \__::reduce($paths, function ($results, $path) use ($collection, $default) {
         return \__::set($results, $path, \__::get($collection, $path, $default));
     }, \__::isObject($collection) ? new \stdClass() : []);

--- a/src/__/collections/pick.php
+++ b/src/__/collections/pick.php
@@ -10,14 +10,14 @@ namespace collections;
  ** __::pick(['a' => 1, 'b' => ['c' => 3, 'd' => 4]], ['a', 'b.d']);
  ** // → ['a' => 1, 'b' => ['d' => 4]]
  *
- * @param array $array         assoc array of values
- * @param array $paths         array of paths to pick
+ * @param array $collection array|object $collection The collection to iterate over.
+ * @param array $paths array paths to pick
  *
  * @return array
  */
-function pick(array $array = [], array $paths = [], $default = null)
+function pick($collection = [], array $paths = [], $default = null)
 {
-    return \__::reduce($paths, function ($results, $path) use ($array, $default) {
-        return \__::set($results, $path, \__::get($array, $path, $default));
+    return \__::reduce($paths, function ($results, $path) use ($collection, $default) {
+        return \__::set($results, $path, \__::get($collection, $path, $default));
     }, []);
 }

--- a/src/__/collections/pluck.php
+++ b/src/__/collections/pluck.php
@@ -19,7 +19,7 @@ function pluck($collection, $property)
             return $value->{$property};
         }
 
-        foreach (\explode('.', $property) as $segment) {
+        foreach (\__::split($property, '.') as $segment) {
             if (\is_object($value)) {
                 if (isset($value->{$segment})) {
                     $value = $value->{$segment};

--- a/src/__/collections/reduce.php
+++ b/src/__/collections/reduce.php
@@ -55,7 +55,7 @@ namespace collections;
  ** // >>     '2' => ['b']
  ** // >> ]
  *
- * @param array|object  $collection The collection to iterate over.
+ * @param array|object $collection The collection to iterate over.
  * @param \Closure $iteratee The function invoked per iteration.
  * @param (*) [$accumulator] The initial value.
  *

--- a/src/__/collections/reduce.php
+++ b/src/__/collections/reduce.php
@@ -67,8 +67,11 @@ function reduce($collection, \Closure $iteratee, $accumulator = NULL)
     if ($accumulator === NULL) {
         $accumulator = \__::first($collection);
     }
-    foreach ($collection as $key => $value) {
-        $accumulator = $iteratee($accumulator, $value, $key, $collection);
-    }
+    \__::doForEach(
+        $collection,
+        function ($value, $key, $collection) use(&$accumulator, $iteratee) {
+            $accumulator = $iteratee($accumulator, $value, $key, $collection);
+        }
+    );
     return $accumulator;
 }

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -3,38 +3,52 @@
 namespace collections;
 
 /**
- * Set item of an array by index to given value, accepting nested index
+ * Set item of a collection by index to given value, accepting nested index.
  *
  ** __::set(['foo' => ['bar' => 'ter']], 'foo.baz.ber', 'fer');
  ** // → '['foo' => ['bar' => 'ter', 'baz' => ['ber' => 'fer']]]'
  *
- * @param array   $collection array of values
- * @param string  $key        key or index
+ * @param array|object $collection collection of values
+ * @param string  $path        key or index
  * @param mixed   $value      the value to set at position $key
  * @param boolean $strict     if the path should be generated even if the path consists of non collections
  * @throws \Exception if the path consists of a non collection and strict is set to false
  *
- * @return array the manipulated array
+ * @return array|object the manipulated collection
  *
  */
-function set(array $collection, $key, $value = null, $strict = false)
+function set($collection, $keys, $value = null, $strict = false)
 {
-    if ($key === null) {
+    $set_object = function (&$object, $key, $value) {
+        $object->$key = $value;
+        return $object;
+    };
+    $set_array = function (&$array, $key, $value) {
+        $array[$key] = $value;
+        return $array;
+    };
+    $setter = \__::isObject($collection) ? $set_object : $set_array;
+
+    if ($keys === null) {
         return $collection;
     }
 
-    $keys = \explode('.', $key);
+    $keys = \explode('.', $keys);
     $key  = \array_shift($keys);
 
     if (\count($keys) === 0) {
-        $collection[$key] = $value;
+        call_user_func_array($setter, [&$collection, $key, $value]);
+        // $collection = call_user_func_array($setter, [&$collection, $key, $value]);
     } else {
-        if (!\array_key_exists($key, $collection) || (!\is_array($collection[$key]) && $strict)) {
+        if (!\__::has($collection, $key) || (!\is_array(\__::get($collection, $key)) && $strict)) {
             $collection[$key] = [];
-        } elseif (!\is_array($collection[$key])) {
+        } elseif (!\is_array(\__::get($collection, $key))) {
             throw new \Exception(sprintf('Could not insert value %s into array because the value at key %s is no array.', $value, $key));
         }
-        $collection[$key] = set($collection[$key], implode('.', $keys), $value);
+        call_user_func_array(
+            $setter,
+            [&$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value)]
+        );
     }
 
     return $collection;

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -3,27 +3,28 @@
 namespace collections;
 
 /**
- * Set item of a collection by index to given value, accepting nested index.
+ * Return a new collection with the item set at index to given value.
+ * Index can be a path of nested indexes.
  *
  ** __::set(['foo' => ['bar' => 'ter']], 'foo.baz.ber', 'fer');
  ** // → '['foo' => ['bar' => 'ter', 'baz' => ['ber' => 'fer']]]'
  *
  * @param array|object $collection collection of values
- * @param string  $path        key or index
- * @param mixed   $value      the value to set at position $key
- * @param boolean $strict     if the path should be generated even if the path consists of non collections
+ * @param string  $path key or index
+ * @param mixed   $value the value to set at position $key
+ * @param boolean $strict if the path should be generated even if the path consists of non collections
  * @throws \Exception if the path consists of a non collection and strict is set to false
  *
- * @return array|object the manipulated collection
+ * @return array|object the new collection with the item set
  *
  */
 function set($collection, $keys, $value = null, $strict = false)
 {
-    $set_object = function (&$object, $key, $value) {
+    $set_object = function ($object, $key, $value) {
         $object->$key = $value;
         return $object;
     };
-    $set_array = function (&$array, $key, $value) {
+    $set_array = function ($array, $key, $value) {
         $array[$key] = $value;
         return $array;
     };
@@ -37,15 +38,14 @@ function set($collection, $keys, $value = null, $strict = false)
     $key  = \array_shift($keys);
 
     if (\count($keys) === 0) {
-        call_user_func_array($setter, [&$collection, $key, $value]);
-        // $collection = call_user_func_array($setter, [&$collection, $key, $value]);
+        $collection = call_user_func_array($setter, [$collection, $key, $value]);
     } else {
         if (!\__::has($collection, $key) || (!\is_array(\__::get($collection, $key)) && $strict)) {
             $collection[$key] = [];
         } elseif (!\is_array(\__::get($collection, $key))) {
             throw new \Exception(sprintf('Could not insert value %s into array because the value at key %s is no array.', $value, $key));
         }
-        call_user_func_array(
+        $collection = call_user_func_array(
             $setter,
             [&$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value)]
         );

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -37,12 +37,10 @@ function set($collection, $path, $value = null)
         return $collection;
     }
 
-    $path = \__::split($path, '.');
-    // TODO Use __::first($portions)
-    $key  = \array_shift($path);
+    $portions = \__::split($path, '.', 2);
+    $key  = $portions[0];
 
-    // TODO Use __::isEmpty($portions)
-    if (\count($path) === 0) {
+    if (\count($portions) === 1) {
         $collection = call_user_func_array($setter, [$collection, $key, $value]);
     } else {
         if (
@@ -58,7 +56,7 @@ function set($collection, $path, $value = null)
         $collection = call_user_func_array(
             $setter,
             // TODO Use __::join(__::drop($portions), '.')
-            [$collection, $key, set(\__::get($collection, $key), implode('.', $path), $value)]
+            [$collection, $key, set(\__::get($collection, $key), $portions[1], $value)]
         );
     }
 

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -60,7 +60,7 @@ function set($collection, $keys, $value = null, $strict = false)
         }
         $collection = call_user_func_array(
             $setter,
-            [$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value)]
+            [$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value, $strict)]
         );
     }
 

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -20,7 +20,7 @@ namespace collections;
  * @return array|object the new collection with the item set
  *
  */
-function set($collection, $keys, $value = null)
+function set($collection, $path, $value = null)
 {
     $set_object = function ($object, $key, $value) {
         $newObject = clone $object;
@@ -33,14 +33,14 @@ function set($collection, $keys, $value = null)
     };
     $setter = \__::isObject($collection) ? $set_object : $set_array;
 
-    if ($keys === null) {
+    if ($path === null) {
         return $collection;
     }
 
-    $keys = \explode('.', $keys);
-    $key  = \array_shift($keys);
+    $path = \explode('.', $path);
+    $key  = \array_shift($path);
 
-    if (\count($keys) === 0) {
+    if (\count($path) === 0) {
         $collection = call_user_func_array($setter, [$collection, $key, $value]);
     } else {
         $empty = \__::isObject($collection) ? new \stdClass : [];
@@ -54,7 +54,7 @@ function set($collection, $keys, $value = null)
         }
         $collection = call_user_func_array(
             $setter,
-            [$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value)]
+            [$collection, $key, set(\__::get($collection, $key), implode('.', $path), $value)]
         );
     }
 

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -37,8 +37,7 @@ function set($collection, $path, $value = null)
         return $collection;
     }
 
-    // TODO Use $portions = __::split('.', $path);
-    $path = \explode('.', $path);
+    $path = \__::split($path, '.');
     // TODO Use __::first($portions)
     $key  = \array_shift($path);
 

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -37,9 +37,12 @@ function set($collection, $path, $value = null)
         return $collection;
     }
 
+    // TODO Use $portions = __::split('.', $path);
     $path = \explode('.', $path);
+    // TODO Use __::first($portions)
     $key  = \array_shift($path);
 
+    // TODO Use __::isEmpty($portions)
     if (\count($path) === 0) {
         $collection = call_user_func_array($setter, [$collection, $key, $value]);
     } else {
@@ -54,6 +57,7 @@ function set($collection, $path, $value = null)
         }
         $collection = call_user_func_array(
             $setter,
+            // TODO Use __::join(__::drop($portions), '.')
             [$collection, $key, set(\__::get($collection, $key), implode('.', $path), $value)]
         );
     }

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -46,14 +46,15 @@ function set($collection, $path, $value = null)
     if (\count($path) === 0) {
         $collection = call_user_func_array($setter, [$collection, $key, $value]);
     } else {
-        $empty = \__::isObject($collection) ? new \stdClass : [];
-        if (!\__::has($collection, $key)) {
-            $collection = call_user_func_array($setter, [$collection, $key, $empty]);
-        } elseif (
-            (\__::isObject($collection) && !\__::isObject(\__::get($collection, $key)))
+        if (
+            !\__::has($collection, $key)
+            || (\__::isObject($collection) && !\__::isObject(\__::get($collection, $key)))
             || (\__::isArray($collection) && !\__::isArray(\__::get($collection, $key)))
         ) {
-            $collection = call_user_func_array($setter, [$collection, $key, $empty]);
+            $collection = call_user_func_array(
+                $setter,
+                [$collection, $key, \__::isObject($collection) ? new \stdClass : []]
+            );
         }
         $collection = call_user_func_array(
             $setter,

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -6,19 +6,21 @@ namespace collections;
  * Return a new collection with the item set at index to given value.
  * Index can be a path of nested indexes.
  *
+ * If a portion of path doesn't exist, it's created. Arrays are created for missing
+ * index in an array; objects are created for missing property in an object.
+ *
  ** __::set(['foo' => ['bar' => 'ter']], 'foo.baz.ber', 'fer');
  ** // → '['foo' => ['bar' => 'ter', 'baz' => ['ber' => 'fer']]]'
  *
  * @param array|object $collection collection of values
  * @param string  $path key or index
  * @param mixed   $value the value to set at position $key
- * @param boolean $strict if the path should be generated even if the path consists of non collections
  * @throws \Exception if the path consists of a non collection and strict is set to false
  *
  * @return array|object the new collection with the item set
  *
  */
-function set($collection, $keys, $value = null, $strict = false)
+function set($collection, $keys, $value = null)
 {
     $set_object = function ($object, $key, $value) {
         $newObject = clone $object;
@@ -45,22 +47,14 @@ function set($collection, $keys, $value = null, $strict = false)
         if (!\__::has($collection, $key)) {
             $collection = call_user_func_array($setter, [$collection, $key, $empty]);
         } elseif (
-            $strict
-            && (
-                (\__::isObject($collection) && !\__::isObject(\__::get($collection, $key)))
-                || (\__::isArray($collection) && !\__::isArray(\__::get($collection, $key)))
-            )
-        ) {
-            $collection = call_user_func_array($setter, [$collection, $key, $empty]);
-        } elseif (
             (\__::isObject($collection) && !\__::isObject(\__::get($collection, $key)))
             || (\__::isArray($collection) && !\__::isArray(\__::get($collection, $key)))
         ) {
-            throw new \Exception(sprintf('Could not insert value %s into array because the value at key %s is no array.', $value, $key));
+            $collection = call_user_func_array($setter, [$collection, $key, $empty]);
         }
         $collection = call_user_func_array(
             $setter,
-            [$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value, $strict)]
+            [$collection, $key, set(\__::get($collection, $key), implode('.', $keys), $value)]
         );
     }
 

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -11,7 +11,7 @@ namespace __;
  ** Arrays                                       [8]
  ** Collections                                 [15]
  ** Functions                                    [3]
- ** Objects                                      [7]
+ ** Objects                                      [8]
  ** Utilities                                    [0]
  ** Strings                                     [12]
  ** Sequences                                    [1]
@@ -69,6 +69,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static bool isNumber($var)
  * @method static bool isObject($var)
  * @method static bool isString($var)
+ * @method static bool isCollection($var)
  *
  * @method static int now()
  * @method static mixed identity()

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -8,11 +8,11 @@ namespace __;
  ___________________________________________________
  ***************************************************
 
- ** Arrays                                       [9]
- ** Collections                                 [17]
+ ** Arrays                                       [10]
+ ** Collections                                 [22]
  ** Functions                                    [3]
  ** Objects                                      [8]
- ** Utilities                                    [0]
+ ** Utilities                                    [2]
  ** Strings                                     [13]
  ** Sequences                                    [1]
 
@@ -44,6 +44,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array filter(array|\Traversable $input, \Closure $func = null) Returns the values in the collection that pass the truth test.
  * @method static array|mixed first(array $input, int $count = null) Gets the first element of an array. Passing n returns the first n elements.
  * @method static null doForEach(array|object $collection, \Closure $iteratee) Iterate over elements of the collection and invokes iteratee for each element.
+ * @method static bool every(array|object $collection, \Closure $iteratee) Checks if predicate returns truthy for all elements of collection.
  * @method static array|mixed get(array|object $collection, string $path, \Closure|mixed $default = null)
  * @method static array groupBy(array $input, int|float|string|\Closure $key) Returns an associative array where the keys are values of $key.
  * @method static bool has($collection, $key) Returns true if $collection contains the requested $key.

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,7 +9,7 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [9]
- ** Collections                                 [16]
+ ** Collections                                 [17]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [0]
@@ -47,6 +47,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array groupBy(array $input, int|float|string|\Closure $key) Returns an associative array where the keys are values of $key.
  * @method static bool has($collection, $key) Returns true if $collection contains the requested $key.
  * @method static bool hasKeys(array $input, array $keys, $strict = false) Returns if $input contains all requested $keys. If $strict is true it also checks if $input exclusively contains the given $keys.
+ * @method static bool isEmpty($value) Check if $value is an empty array or object.
  * @method static array|mixed last(array $input, int $count = null) Gets the last element of an array. Passing n returns the last n elements.
  * @method static array map(array $input, \Closure $func = null) Returns an array of values by mapping each in collection through the iterator.
  * @method static array mapKeys(array $input, \Closure $func = null) Returns an array with keys being mapped through the iterator

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,7 +9,7 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [8]
- ** Collections                                 [15]
+ ** Collections                                 [16]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [0]
@@ -44,6 +44,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array|mixed first(array $input, int $count = null) Gets the first element of an array. Passing n returns the first n elements.
  * @method static array|mixed get(array|object $input, string $path, \Closure|mixed $default = null)
  * @method static array groupBy(array $input, int|float|string|\Closure $key) Returns an associative array where the keys are values of $key.
+ * @method static bool has($collection, $key) Returns true if $collection contains the requested $key.
  * @method static bool hasKeys(array $input, array $keys, $strict = false) Returns if $input contains all requested $keys. If $strict is true it also checks if $input exclusively contains the given $keys.
  * @method static array|mixed last(array $input, int $count = null) Gets the last element of an array. Passing n returns the last n elements.
  * @method static array map(array $input, \Closure $func = null) Returns an array of values by mapping each in collection through the iterator.

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -43,20 +43,21 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array ease(array $input, string $glue = '.')
  * @method static array filter(array|\Traversable $input, \Closure $func = null) Returns the values in the collection that pass the truth test.
  * @method static array|mixed first(array $input, int $count = null) Gets the first element of an array. Passing n returns the first n elements.
- * @method static array|mixed get(array|object $input, string $path, \Closure|mixed $default = null)
+ * @method static null doForEach(array|object $collection, \Closure $iteratee) Iterate over elements of the collection and invokes iteratee for each element.
+ * @method static array|mixed get(array|object $collection, string $path, \Closure|mixed $default = null)
  * @method static array groupBy(array $input, int|float|string|\Closure $key) Returns an associative array where the keys are values of $key.
  * @method static bool has($collection, $key) Returns true if $collection contains the requested $key.
  * @method static bool hasKeys(array $input, array $keys, $strict = false) Returns if $input contains all requested $keys. If $strict is true it also checks if $input exclusively contains the given $keys.
  * @method static bool isEmpty($value) Check if $value is an empty array or object.
  * @method static array|mixed last(array $input, int $count = null) Gets the last element of an array. Passing n returns the last n elements.
- * @method static array map(array $input, \Closure $func = null) Returns an array of values by mapping each in collection through the iterator.
+ * @method static array map(array|object $collection, \Closure $func = null) Returns an array of values by mapping each in collection through the iterator.
  * @method static array mapKeys(array $input, \Closure $func = null) Returns an array with keys being mapped through the iterator
  * @method static array mapValues(array $input, \Closure $func = null) Returns an array with values being mapped through the iterator
  * @method static array max(array|\Traversable $input) Returns the maximum value from the collection. If passed an iterator, max will return max value returned by the iterator.
  * @method static array min(array|\Traversable $input) Returns the minimum value from the collection. If passed an iterator, min will return min value returned by the iterator.
  * @method static array pluck(array|object $input, string $key) Returns an array of values belonging to a given property of each item in a collection.
  * @method static mixed reduce(array|\Traversable $input, \Closure $iteratee, mixed $accumulator = null) Reduces a collection to a value which is the $accumulator result of running each element in the collection thru $iteratee, where each successive invocation is supplied the return value of the previous.
- * @method static array set(array $collection = [], string $key = '', $value = null, $strict = false) Set item of an array by index to given value, aceepting nested index
+ * @method static array set(array|object $collection = [], string $key = '', $value = null, $strict = false) Set item of an array by index to given value, aceepting nested index
 * @method static array pick(array $array = [], array $paths = [], $default = null) Returns an array having only keys present in the given path list.
  * @method static array unease(array $input, string $separator = '.')
  * @method static array where(array|\Traversable $input, mixed $itemParams = '')

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -8,7 +8,7 @@ namespace __;
  ___________________________________________________
  ***************************************************
 
- ** Arrays                                       [8]
+ ** Arrays                                       [9]
  ** Collections                                 [16]
  ** Functions                                    [3]
  ** Objects                                      [8]
@@ -32,6 +32,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array append(array $input, $item) <code>__::append([1, 2, 3], 4)</code> >> [1, 2, 3, 4]
  * @method static array chunk(array $input, $size = 1, $preserveKeys = false) Creates an array of elements split into groups the length of size. If array can't be split evenly, the final chunk will be the remaining elements. <code>__::chunk([1, 2, 3, 4, 5], 3)</code> >> [1, 2, 3], [4, 5]
  * @method static array compact(array $input) Returns a copy of the array with falsy values removed. <code>__::compact([0, 1, false, 2, '', 3])</code> >> [1, 2, 3]
+ * @method static array drop(array $input, int $number = 1) Creates a slice of array with n elements dropped from the beginning.
  * @method static array flatten(array $input, bool $shallow = false) Flattens a multidimensional array. If you pass shallow, the array will only be flattened a single level.
  * @method static array patch(array $input, array $patches) Patches array with list of xpath-value pairs.
  * @method static array prepend(array $input, $item)
@@ -81,7 +82,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static string lowerCase(string $input)
  * @method static string lowerFirst(string $input)
  * @method static string snakeCase(string $input)
- * @method static array split(string $input, string $delimiter[, integer $limit])
+ * @method static array split(string $input, string $delimiter[, int $limit]) Split a string by string.
  * @method static string startCase(string $input)
  * @method static string toLower(string $input)
  * @method static string toUpper(string $input)

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -13,7 +13,7 @@ namespace __;
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [0]
- ** Strings                                     [12]
+ ** Strings                                     [13]
  ** Sequences                                    [1]
 
  ***************************************************
@@ -81,6 +81,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static string lowerCase(string $input)
  * @method static string lowerFirst(string $input)
  * @method static string snakeCase(string $input)
+ * @method static array split(string $input, string $delimiter[, integer $limit])
  * @method static string startCase(string $input)
  * @method static string toLower(string $input)
  * @method static string toUpper(string $input)

--- a/src/__/objects/isCollection.php
+++ b/src/__/objects/isCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace objects;
+
+/**
+ * Check if the object is a collection.
+ * A collection is either an array or an object.
+ *
+ * @param null $object
+ *
+ * @return bool
+ */
+function isCollection($object)
+{
+    return \__::isArray($object) || \__::isObject($object);
+}

--- a/src/__/strings/split.php
+++ b/src/__/strings/split.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace strings;
+
+/**
+ * Split a string by string.
+ *
+ * Based on explode, see http://php.net/manual/en/function.explode.php.
+ *
+ * __::split('a-b-c', '-', 2);
+ *      >> ['a', 'b-c']
+ *
+ * @param string $input The string to split.
+ * @param string $delimeter The boundary string.
+ * @param [optional] $limit If limit is set and positive, the returned array
+ * will contain a maximum of limit elements with the last element containing the
+ * rest of string.
+ * If the limit parameter is negative, all components except the last -limit are returned.
+ * If the limit parameter is zero, then this is treated as 1.
+ *
+ * @return string
+ *
+ */
+function split($input, $delimeter, $limit = PHP_INT_MAX)
+{
+    return explode($delimeter, $input, $limit);
+}

--- a/tests/arrays.php
+++ b/tests/arrays.php
@@ -47,6 +47,24 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([1, 2, 3], $x);
     }
 
+    public function testDrop()
+    {
+        // Arrange
+        $a = [1, 2, 3];
+
+        // Act
+        $x = __::drop($a);
+        $y = __::drop($a, 2);
+        $z = __::drop($a, 5);
+        $xa = __::drop($a, 0);
+
+        // Assert
+        $this->assertEquals([2, 3], $x);
+        $this->assertEquals([3], $y);
+        $this->assertEquals([], $z);
+        $this->assertEquals([1, 2, 3], $xa);
+    }
+
     public function testFlatten()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -525,7 +525,7 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         // Act
         $x = __::set($a, 'foo.baz.ber', 'fer');
-        $y = __::set($a, 'foo.bar', 'fer2', true);
+        $y = __::set($a, 'foo.bar', 'fer2');
 
         // Assert
         $this->assertEquals(['foo' => ['bar' => 'ter']], $a);
@@ -540,7 +540,7 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         // Act.
         $x = __::set($a, 'foo.baz.ber', 'fer');
-        $y = __::set($a, 'foo.bar', 'fer2', true);
+        $y = __::set($a, 'foo.bar', 'fer2');
 
         // Assert.
         $this->assertEquals((object )['foo' => (object) ['bar' => 'ter']], $a);
@@ -548,23 +548,17 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals((object) ['foo' => (object) ['bar' => 'fer2']], $y);
     }
 
-    public function testSetStrictException()
+    public function testSetOveride()
     {
-        if (method_exists($this, 'expectException')) {
-            // new phpunit
-            $this->expectException('\Exception');
-        } else {
-            // old phpunit
-            $this->setExpectedException('\Exception');
-        }
-
         // Arrange
-        $a = [
-            'foo' => ['bar' => 'ter']
-        ];
+        $a = ['foo' => ['bar' => 'ter']];
 
         // Act
-        __::set($a, 'foo.bar.not_exist', 'baz', true);
+        $x = __::set($a, 'foo.bar.not_exist', 'baz');
+
+        // Assert.
+        $this->assertEquals(['foo' => ['bar' => 'ter']], $a);
+        $this->assertEquals(['foo' => ['bar' => ['not_exist' => 'baz']]], $x);
     }
 
     public function testWhere()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -208,6 +208,25 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('Indianapolis', $grouped);
     }
 
+    public function testHas()
+    {
+        // Arrange.
+        $a = ['foo' => 'bar'];
+        $b = (object) ['foo' => 'bar'];
+
+        // Act.
+        $x = __::has($a, 'foo');
+        $y = __::has($a, 'foz');
+        $z = __::has($b, 'foo');
+        $x1 = __::has($b, 'foz');
+
+        // Assert.
+        $this->assertTrue($x);
+        $this->assertFalse($y);
+        $this->assertTrue($z);
+        $this->assertFalse($x1);
+    }
+
     public function testHasKeys()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -457,6 +457,31 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         ], $x);
     }
 
+    public function testPickDefaults()
+    {
+        // Arrange.
+        $a = ['nasa' => 1, 'cnsa' => 42];
+        $b = ['a' => 1, 'b' => ['c' => 3, 'd' => 4]];
+
+        // Act.
+        $x = __::pick($a, ['nasa', 'cnsa', 'esa', 'jaxa'], 26);
+        $y = __::pick($b, ['a', 'b.d', 'e', 'f.g'], 'default');
+
+        // Assert.
+        $this->assertEquals([
+            'nasa' => 1,
+            'cnsa' => 42,
+            'esa' => 26,
+            'jaxa' => 26,
+        ], $x);
+        $this->assertEquals([
+            'a' => 1,
+            'b' => ['d' => 4],
+            'e' => 'default',
+            'f' => ['g' => 'default']
+        ], $y);
+    }
+
     public function testSet()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -513,6 +513,20 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['foo' => ['bar' => 'fer2']], $y);
     }
 
+    public function testSetObject()
+    {
+        // Arrange.
+        $a = (object) ['foo' => ['bar' => 'ter']];
+
+        // Act.
+        $x = __::set($a, 'foo.baz.ber', 'fer');
+        $y = __::set($a, 'foo.bar', 'fer2', true);
+
+        // Assert.
+        $this->assertEquals((object) ['ber' => 'fer'], $x->foo->baz);
+        $this->assertEquals((object) ['foo' => ['bar' => 'fer2']], $y);
+    }
+
     public function testSetStrictException()
     {
         if (method_exists($this, 'expectException')) {

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -265,23 +265,15 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
     public function testIsEmpty()
     {
-        // Arrange.
-        $a = [];
-        $b = ['Falcon', 'Heavy'];
-        $c = new stdClass();
-        $d = (object) ['Baie' => 'Goji'];
-
-        // Act.
-        $x = __::isEmpty($a);
-        $y = __::isEmpty($b);
-        $z = __::isEmpty($c);
-        $xa = __::isEmpty($d);
-
-        // Assert.
-        $this->assertTrue($x);
-        $this->assertFalse($y);
-        $this->assertTrue($z);
-        $this->assertFalse($xa);
+        // Assert nominal cases.
+        $this->assertTrue(__::isEmpty([]));
+        $this->assertFalse(__::isEmpty(['Falcon', 'Heavy']));
+        $this->assertTrue(__::isEmpty(new stdClass()));
+        $this->assertFalse(__::isEmpty((object) ['Baie' => 'Goji']));
+        // Assert on non-collections.
+        $this->assertTrue(__::isEmpty(null));
+        $this->assertTrue(__::isEmpty(3));
+        $this->assertTrue(__::isEmpty(true));
     }
 
     public function testLast()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -308,6 +308,20 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($y);
     }
 
+    public function testHasKeysObject()
+    {
+        // Arrange.
+        $a = (object) ['foo' => 'bar'];
+
+        // Act
+        $x = __::hasKeys($a, ['foo']);
+        $y = __::hasKeys($a, ['foo', 'foz']);
+
+        // Assert
+        $this->assertTrue($x);
+        $this->assertFalse($y);
+    }
+
     public function testIsEmpty()
     {
         // Assert nominal cases.

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -263,6 +263,27 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($y);
     }
 
+    public function testIsEmpty()
+    {
+        // Arrange.
+        $a = [];
+        $b = ['Falcon', 'Heavy'];
+        $c = new stdClass();
+        $d = (object) ['Baie' => 'Goji'];
+
+        // Act.
+        $x = __::isEmpty($a);
+        $y = __::isEmpty($b);
+        $z = __::isEmpty($c);
+        $xa = __::isEmpty($d);
+
+        // Assert.
+        $this->assertTrue($x);
+        $this->assertFalse($y);
+        $this->assertTrue($z);
+        $this->assertFalse($xa);
+    }
+
     public function testLast()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -304,6 +304,20 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([3, 6, 9], $x);
     }
 
+    public function testMapObject()
+    {
+        // Arrange
+        $a = (object) ['a' => 1, 'b' => 2, 'c' => 3];
+
+        // Act
+        $x = __::map($a, function($n, $key) {
+            return $key === 'c' ? $n : $n * 3;
+        });
+
+        // Assert
+        $this->assertEquals([3, 6, 3], $x);
+    }
+
     public function testMax()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -276,32 +276,38 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         // Arrange.
         $a = ['foo' => 'bar'];
         $b = (object) ['foo' => 'bar'];
+        $c = ['foo' => ['bar' => 'foie']];
 
         // Act.
         $x = __::has($a, 'foo');
         $y = __::has($a, 'foz');
         $z = __::has($b, 'foo');
-        $x1 = __::has($b, 'foz');
+        $xa = __::has($b, 'foz');
+        $xb = __::has($c, 'foo.bar');
 
         // Assert.
         $this->assertTrue($x);
         $this->assertFalse($y);
         $this->assertTrue($z);
-        $this->assertFalse($x1);
+        $this->assertFalse($xa);
+        $this->assertTrue($xb);
     }
 
     public function testHasKeys()
     {
         // Arrange
         $a = ['foo' => 'bar'];
+        $b = ['foo' => ['bar' => 'foie'], 'estomac' => true];
 
         // Act
         $x = __::hasKeys($a, ['foo', 'foz'], false);
         $y = __::hasKeys($a, ['foo', 'foz'], true);
+        $z = __::hasKeys($b, ['foo.bar', 'estomac']);
 
         // Assert
         $this->assertFalse($x);
         $this->assertFalse($y);
+        $this->assertTrue($z);
 
         //Rearrange
         $a['foz'] = 'baz';

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -94,6 +94,24 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($b, $bMapped);
     }
 
+    public function testEvery()
+    {
+        // Arrange.
+        $a = [true, 1, null, 'yes'];
+        $b = [true, false];
+        $c = [1, 3, 4];
+
+        // Act.
+        $x = __::every($a, 'is_bool');
+        $y = __::every($b, 'is_bool');
+        $c = __::every($b, 'is_int');
+
+        // Assert
+        $this->assertFalse($a);
+        $this->assertTrue($b);
+        $this->assertTrue($c);
+    }
+
     public function testDoForEachPrematureReturn()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -493,10 +493,10 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $x = __::pick($a, ['marseille', 'london']);
 
         // Assert.
-        $this->assertEquals([
-            'marseille' => 1578484,
-            'london' => null
-        ], $x);
+        $i = new \stdClass();
+        $i->marseille = 1578484;
+        $i->london = null;
+        $this->assertEquals($i, $x);
     }
 
     public function testSet()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -493,10 +493,10 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $x = __::pick($a, ['marseille', 'london']);
 
         // Assert.
-        $i = new \stdClass();
-        $i->marseille = 1578484;
-        $i->london = null;
-        $this->assertEquals($i, $x);
+        $this->assertEquals((object) [
+            'marseille' => 1578484,
+            'london' => null
+        ], $x);
     }
 
     public function testSet()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -528,24 +528,24 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $y = __::set($a, 'foo.bar', 'fer2', true);
 
         // Assert
+        $this->assertEquals(['foo' => ['bar' => 'ter']], $a);
         $this->assertEquals(['ber' => 'fer'], $x['foo']['baz']);
         $this->assertEquals(['foo' => ['bar' => 'fer2']], $y);
-        $this->assertEquals(['foo' => ['bar' => 'ter']], $a);
     }
 
     public function testSetObject()
     {
         // Arrange.
-        $a = (object) ['foo' => ['bar' => 'ter']];
+        $a = (object) ['foo' => (object) ['bar' => 'ter']];
 
         // Act.
         $x = __::set($a, 'foo.baz.ber', 'fer');
         $y = __::set($a, 'foo.bar', 'fer2', true);
 
         // Assert.
+        $this->assertEquals((object )['foo' => (object) ['bar' => 'ter']], $a);
         $this->assertEquals((object) ['ber' => 'fer'], $x->foo->baz);
-        $this->assertEquals((object) ['foo' => ['bar' => 'fer2']], $y);
-        $this->assertEquals((object )['foo' => ['bar' => 'ter']], $a);
+        $this->assertEquals((object) ['foo' => (object) ['bar' => 'fer2']], $y);
     }
 
     public function testSetStrictException()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -72,6 +72,28 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals([1, 2], $x);
     }
 
+    public function testDoForEach()
+    {
+        // Arrange
+        $makeMapper = function (&$array) {
+            return function ($value, $key) use(&$array) {
+                $array[$key] = $value;
+            };
+        };
+        $a = [1, 2, 3];
+        $b = ['state' => 'IN', 'city' => 'Indianapolis', 'object' => 'School bus'];
+
+        // Act.
+        $aMapped = [];
+        $bMapped = [];
+        __::doForEach($a, $makeMapper($aMapped));
+        __::doForEach($b, $makeMapper($bMapped));
+
+        // Assert
+        $this->assertEquals($a, $aMapped);
+        $this->assertEquals($b, $bMapped);
+    }
+
     public function testGetArrays()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -443,7 +443,7 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
     public function testPick()
     {
         // Arrange
-        $a = ['a' => 1, 'b' => ['c' => 3, 'd' => 4]];
+        $a = ['a' => 1, 'b' => ['c' => 3, 'd' => 4], 'h' => 5];
 
         // Act
         $x = __::pick($a, ['a', 'b.d', 'e', 'f.g']);
@@ -464,12 +464,11 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $b = ['a' => 1, 'b' => ['c' => 3, 'd' => 4]];
 
         // Act.
-        $x = __::pick($a, ['nasa', 'cnsa', 'esa', 'jaxa'], 26);
+        $x = __::pick($a, ['cnsa', 'esa', 'jaxa'], 26);
         $y = __::pick($b, ['a', 'b.d', 'e', 'f.g'], 'default');
 
         // Assert.
         $this->assertEquals([
-            'nasa' => 1,
             'cnsa' => 42,
             'esa' => 26,
             'jaxa' => 26,
@@ -480,6 +479,24 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
             'e' => 'default',
             'f' => ['g' => 'default']
         ], $y);
+    }
+
+    public function testPickObject()
+    {
+        // Arrange.
+        $a = new \stdClass();
+        $a->paris = 10659489;
+        $a->marseille = 1578484;
+        $a->lyon = 1620331;
+
+        // Act.
+        $x = __::pick($a, ['marseille', 'london']);
+
+        // Assert.
+        $this->assertEquals([
+            'marseille' => 1578484,
+            'london' => null
+        ], $x);
     }
 
     public function testSet()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -102,14 +102,14 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $c = [1, 3, 4];
 
         // Act.
-        $x = __::every($a, 'is_bool');
-        $y = __::every($b, 'is_bool');
-        $c = __::every($b, 'is_int');
+        $x = __::every($a, function ($v) { return is_bool($v); });
+        $y = __::every($b, function ($v) { return is_bool($v); });
+        $z = __::every($c, function ($v) { return is_int($v); });
 
         // Assert
-        $this->assertFalse($a);
-        $this->assertTrue($b);
-        $this->assertTrue($c);
+        $this->assertFalse($x);
+        $this->assertTrue($y);
+        $this->assertTrue($z);
     }
 
     public function testDoForEachPrematureReturn()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -94,6 +94,29 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($b, $bMapped);
     }
 
+    public function testDoForEachPrematureReturn()
+    {
+        // Arrange
+        $makeMapper = function (&$array, $returnAtKey) {
+            return function ($value, $key) use(&$array, $returnAtKey) {
+                $array[$key] = $value;
+                if ($returnAtKey === $key) return false;
+            };
+        };
+        $a = [1, 2, 3, 4];
+        $b = ['state' => 'IN', 'city' => 'Indianapolis', 'object' => 'School bus'];
+
+        // Act.
+        $aMapped = [];
+        $bMapped = [];
+        __::doForEach($a, $makeMapper($aMapped, 1));
+        __::doForEach($b, $makeMapper($bMapped,  'city'));
+
+        // Assert
+        $this->assertEquals([1, 2], $aMapped);
+        $this->assertEquals(['state' => 'IN', 'city' => 'Indianapolis'], $bMapped);
+    }
+
     public function testGetArrays()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -530,6 +530,7 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         // Assert
         $this->assertEquals(['ber' => 'fer'], $x['foo']['baz']);
         $this->assertEquals(['foo' => ['bar' => 'fer2']], $y);
+        $this->assertEquals(['foo' => ['bar' => 'ter']], $a);
     }
 
     public function testSetObject()
@@ -544,6 +545,7 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         // Assert.
         $this->assertEquals((object) ['ber' => 'fer'], $x->foo->baz);
         $this->assertEquals((object) ['foo' => ['bar' => 'fer2']], $y);
+        $this->assertEquals((object )['foo' => ['bar' => 'ter']], $a);
     }
 
     public function testSetStrictException()

--- a/tests/objects.php
+++ b/tests/objects.php
@@ -88,5 +88,23 @@ class ObjectsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(true, $x);
     }
 
+    public function testIsCollection()
+    {
+        // Arrange.
+        $a = [1, 2, 3];
+        $b = (object) [1, 2, 3];
+        $c = 'string';
+
+        // Act.
+        $x = __::isCollection($a);
+        $y = __::isCollection($b);
+        $z = __::isCollection($c);
+
+        // Assert.
+        $this->assertEquals(true, $x);
+        $this->assertEquals(true, $y);
+        $this->assertEquals(false, $z);
+    }
+
     // ...
 }

--- a/tests/strings.php
+++ b/tests/strings.php
@@ -103,6 +103,23 @@ class StringsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('foo_bar', $z);
     }
 
+    public function testSplit()
+    {
+        // Arrange
+        $a = 'github.com';
+        $b = 'a-b-c';
+
+        // Act
+        $x = __::split($a, '.');
+        $y = __::split($b, '-');
+        $z = __::split($b, '-', 2);
+
+        // Assert
+        $this->assertEquals(['github', 'com'], $x);
+        $this->assertEquals(['a', 'b', 'c'], $y);
+        $this->assertEquals(['a', 'b-c'], $z);
+    }
+
     public function testStartCase()
     {
         // Arrange


### PR DESCRIPTION
As mentioned in #35, we could make collection functions work on associative arrays but also objects.

This is a work in progress: tested on `__::pick()`, the next step is to add test cases with objects on each collection functions.
  
I let you know when it is to be reviewed for merge!