### PR TITLE
Merge collections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 script:
   - php bench.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `__::concat`
 * Added `__::concatDeep`
 * Added `__::merge`
+* Added `__::doForEachRight`
 
 ## <sub>v0.1.1</sub>
 #### _Jan 12, 2018_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.0...0.1.1) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.1/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## <sub>unreleased</sub>
 #### [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.1...master) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/master/README.md)
 * Added `__::assign`
+* Added `__::concat`
+* Added `__::concatDeep`
 * Added `__::merge`
 
 ## <sub>v0.1.1</sub>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## <sub>unreleased</sub>
 #### [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.1...master) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/master/README.md)
+* Added `__::assign`
+* Added `__::merge`
 
 ## <sub>v0.1.1</sub>
 #### _Jan 12, 2018_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.0...0.1.1) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.1/README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `__::concatDeep`
 * Added `__::merge`
 * Added `__::doForEachRight`
+* Added `__::reduceRight`
 
 ## <sub>v0.1.1</sub>
 #### _Jan 12, 2018_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.0...0.1.1) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.1/README.md)

--- a/README.md
+++ b/README.md
@@ -227,7 +227,22 @@ __::doForEach(
         print_r($n)
     }
 );
-// >> (Side effect: print numbers)
+// (Side effect: print numbers)
+// >> 1, 2, 3
+```
+
+##### [__::doForEachRight](src/__/collections/doForEachRight.php)
+Iterate over elements of the collection, from right to left, and invokes iteratee
+for each element.
+```php
+__::doForEachRight(
+    [1, 2, 3],
+    function ($n) {
+        print_r($n)
+    }
+);
+// (Side effect: print numbers)
+// >> 3, 2, 1
 ```
 
 ##### [__::every](src/__/collections/every.php)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ __::chain([1, 2, 3, 0, null])
 
 ### Collections
 
+##### [__::assign](src/__/collections/assign.php)
+Combines collections provided with each others. If the collections have
+common keys, then the last passed keys override the previous. If numerical indexes
+are passed, then values are appended.
+
+For a recursive merge, see [__::merge](#__::merge).
+```php
+__::assign(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
+// >> ['color' => ['favorite' => 'green', 'blue'], 5, 10]
+```
+
 ##### [__::ease](src/__/collections/ease.php)
 Flattens a complex collection by mapping each ending leafs value to a key consisting of all previous indexes.
 ```php
@@ -311,6 +322,17 @@ Returns the maximum value from the collection. If passed an iterator, max will r
 ```php
 __::max([1, 2, 3]);
 // >> 3
+```
+
+##### [__::merge](src/__/collections/merge.php)
+Recursively combines collections provided with each others. If the collections have
+common keys, then the values are appended in an array. If numerical indexes
+are passed, then values are appended.
+
+For a non-recursive merge, see [__::assign](#__::assign).
+```php
+__::merge(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
+// >> ['color' => ['favorite' => ['red', 'green'], 'blue'], 5, 10]
 ```
 
 ##### [__::min](src/__/collections/min.php)

--- a/README.md
+++ b/README.md
@@ -402,6 +402,17 @@ __::reduce([1, 2], function ($sum, $number) {
 // >> 3
 ```
 
+##### [__::reduceRight](src/__/collections/reduce.php)
+Reduces a collection to a value which is the accumulator result of running each
+element in the collection - from right to left - thru an iteratee function,
+where each successive invocation is supplied the return value of the previous.
+```php
+__::reduceRight(['a', 'b', 'c'], function ($word, $char) {
+    return $word . $char;
+}, '');
+// >> 'cba'
+```
+
 ##### [__::set](src/__/collections/set.php)
 Return a new collection with the item set at index to given value. Index can be a path.
 ```php

--- a/README.md
+++ b/README.md
@@ -158,14 +158,36 @@ __::chain([1, 2, 3, 0, null])
 ### Collections
 
 ##### [__::assign](src/__/collections/assign.php)
-Combines collections provided with each others. If the collections have
-common keys, then the last passed keys override the previous. If numerical indexes
-are passed, then values are appended.
+Combines and merge collections provided with each others.
+If the collections have common keys, then the last passed keys override the previous.
+If numerical indexes are passed, then last passed indexes override the previous.
 
 For a recursive merge, see [__::merge](#__::merge).
 ```php
-__::assign(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
-// >> ['color' => ['favorite' => 'green', 'blue'], 5, 10]
+__::assign(['color' => ['favorite' => 'red', 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+// >> ['color' => ['favorite' => 'green', 'blue'], 10]
+```
+
+##### [__::concat](src/__/collections/concat.php)
+Combines and concat collections provided with each others.
+If the collections have common keys, then the values are appended in an array.
+If numerical indexes are passed, then values are appended.
+
+For a recursive concat, see [__::concatDeep](#__::concatDeep).
+```php
+__::concat(['color' => ['favorite' => 'red', 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+// >> ['color' => ['favorite' => ['green'], 5, 'blue'], 3, 10]
+```
+
+##### [__::concatDeep](src/__/collections/concatDeep.php)
+Recursively combines and concat collections provided with each others.
+If the collections have common keys, then the values are appended in an array.
+If numerical indexes are passed, then values are appended.
+
+For a non-recursive concat, see [__::concat](#__::concat).
+```php
+__::concatDeep(['color' => ['favorite' => 'red', 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+// >> ['color' => ['favorite' => ['red', 'green'], 5, 'blue'], 3, 10]
 ```
 
 ##### [__::ease](src/__/collections/ease.php)
@@ -325,14 +347,14 @@ __::max([1, 2, 3]);
 ```
 
 ##### [__::merge](src/__/collections/merge.php)
-Recursively combines collections provided with each others. If the collections have
-common keys, then the values are appended in an array. If numerical indexes
-are passed, then values are appended.
+Recursively combines and merge collections provided with each others.
+If the collections have common keys, then the last passed keys override the previous.
+If numerical indexes are passed, then last passed indexes override the previous.
 
 For a non-recursive merge, see [__::assign](#__::assign).
 ```php
-__::merge(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
-// >> ['color' => ['favorite' => ['red', 'green'], 'blue'], 5, 10]
+__::merge(['color' => ['favorite' => 'red', 'model' => 3, 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+// >> ['color' => ['favorite' => 'green', 'model' => 3, 'blue'], 10]
 ```
 
 ##### [__::min](src/__/collections/min.php)

--- a/src/__/collections/assign.php
+++ b/src/__/collections/assign.php
@@ -3,14 +3,16 @@
 namespace collections;
 
 /**
- * Combines collections provided with each others. If the collections have
- * common keys, then the last passed keys override the previous. If numerical indexes
- * are passed, then values are appended.
+ * Combines and merge collections provided with each others.
+ *
+ * If the collections have common keys, then the last passed keys override the
+ * previous. If numerical indexes are passed, then last passed indexes override
+ * the previous.
  *
  * For a recursive merge, see __::merge.
  *
- ** __::assign(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
- ** // >> ['color' => ['favorite' => 'green', 'blue'], 5, 10]
+ ** __::assign(['color' => ['favorite' => 'red', 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+ ** // >> ['color' => ['favorite' => 'green', 'blue'], 10]
  *
  * @param array|object $collection1 Collection to assign to.
  * @param array|object $... N other collections to assign.
@@ -20,13 +22,12 @@ namespace collections;
  */
 function assign($collection1, $collection2)
 {
-    // TODO Alternative over casting to array: implement directly assign using
-    // foreach (func_get_args() as $collectionN). (with object handling).
-    // First collection determine output type (array vs. object).
-    $isObject = \__::isObject($collection1);
-    // Cast args to array.
-    $args = \__::map(func_get_args(), function ($arg) { return (array) $arg; });
-    // PHP 5.6+ array_merge_recursive(...$args);
-    $merged = call_user_func_array('array_merge', $args);;
-    return $isObject ? (object) $merged : $merged;
+    // TODO Use __::reduceRight()
+    // (Requires to implement it. Itself may use __::doForEachRight() as base).
+    return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
+        \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
+            $result = \__::set($result, $key, $sourceValue);
+        });
+        return $result;
+    }, []);
 }

--- a/src/__/collections/assign.php
+++ b/src/__/collections/assign.php
@@ -22,9 +22,7 @@ namespace collections;
  */
 function assign($collection1, $collection2)
 {
-    // TODO Use __::reduceRight()
-    // (Requires to implement it. Itself may use __::doForEachRight() as base).
-    return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
+    return \__::reduceRight(func_get_args(), function ($source, $result) {
         \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
             $result = \__::set($result, $key, $sourceValue);
         });

--- a/src/__/collections/assign.php
+++ b/src/__/collections/assign.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace collections;
+
+/**
+ * Combines collections provided with each others. If the collections have
+ * common keys, then the last passed keys override the previous. If numerical indexes
+ * are passed, then values are appended.
+ *
+ * For a recursive merge, see __::merge.
+ *
+ ** __::assign(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
+ ** // >> ['color' => ['favorite' => 'green', 'blue'], 5, 10]
+ *
+ * @param array|object $collection1 Collection to assign to.
+ * @param array|object $... N other collections to assign.
+ *
+ * @return array|object Assigned collection.
+ *
+ */
+function assign($collection1, $collection2)
+{
+    // foreach (func_get_args() as $collectionN) {
+    //
+    // }
+    // PHP 5.6+ array_merge_recursive(...func_get_args());
+    return call_user_func_array('array_merge', func_get_args());
+}

--- a/src/__/collections/assign.php
+++ b/src/__/collections/assign.php
@@ -20,9 +20,13 @@ namespace collections;
  */
 function assign($collection1, $collection2)
 {
-    // foreach (func_get_args() as $collectionN) {
-    //
-    // }
-    // PHP 5.6+ array_merge_recursive(...func_get_args());
-    return call_user_func_array('array_merge', func_get_args());
+    // TODO Alternative over casting to array: implement directly assign using
+    // foreach (func_get_args() as $collectionN). (with object handling).
+    // First collection determine output type (array vs. object).
+    $isObject = \__::isObject($collection1);
+    // Cast args to array.
+    $args = \__::map(func_get_args(), function ($arg) { return (array) $arg; });
+    // PHP 5.6+ array_merge_recursive(...$args);
+    $merged = call_user_func_array('array_merge', $args);;
+    return $isObject ? (object) $merged : $merged;
 }

--- a/src/__/collections/concat.php
+++ b/src/__/collections/concat.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace collections;
+
+/**
+ * Combines and concat collections provided with each others.
+ *
+ * If the collections have common keys, then the values are appended in an array.
+ * If numerical indexes are passed, then values are appended.
+ *
+ * For a recursive merge, see __::merge.
+ *
+ ** __::concat(['color' => ['favorite' => 'red', 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+ ** // >> ['color' => ['favorite' => ['green'], 5, 'blue'], 3, 10]
+ *
+ * @param array|object $collection1 Collection to assign to.
+ * @param array|object $... N other collections to assign.
+ *
+ * @return array|object Assigned collection.
+ *
+ */
+function concat($collection1, $collection2)
+{
+    // TODO Alternative over casting to array: implement directly assign using
+    // foreach (func_get_args() as $collectionN). (with object handling).
+    // First collection determine output type (array vs. object).
+    $isObject = \__::isObject($collection1);
+    // Cast args to array.
+    $args = \__::map(func_get_args(), function ($arg) { return (array) $arg; });
+    // PHP 5.6+ array_merge_recursive(...$args);
+    $merged = call_user_func_array('array_merge', $args);;
+    return $isObject ? (object) $merged : $merged;
+}

--- a/src/__/collections/concatDeep.php
+++ b/src/__/collections/concatDeep.php
@@ -21,9 +21,7 @@ namespace collections;
  */
 function concatDeep()
 {
-    // TODO Use __::reduceRight()
-    // (Requires to implement it. Itself may use __::doForEachRight() as base).
-    return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
+    return \__::reduceRight(func_get_args(), function ($source, $result) {
         \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
             if (!\__::has($result, $key)) {
                 $result = \__::set($result, $key, $sourceValue);

--- a/src/__/collections/concatDeep.php
+++ b/src/__/collections/concatDeep.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace collections;
+
+/**
+ * Recursively combines and concat collections provided with each others.
+ *
+ * If the collections have common keys, then the values are appended in an array.
+ * If numerical indexes are passed, then values are appended.
+ *
+ * For a non-recursive concat, see __::concat.
+ *
+ ** __::concatDeep(['color' => ['favorite' => 'red', 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+ ** // >> ['color' => ['favorite' => ['red', 'green'], 5, 'blue'], 3, 10]
+ *
+ * @param array|object $collection1 First collection to concatDeep.
+ * @param array|object $... N other collections to concatDeep.
+ *
+ * @return array|object Concatened collection.
+ *
+ */
+function concatDeep()
+{
+    // TODO Use __::reduceRight()
+    // (Requires to implement it. Itself may use __::doForEachRight() as base).
+    return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
+        \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
+            if (!\__::has($result, $key)) {
+                $result = \__::set($result, $key, $sourceValue);
+            } else if(is_numeric($key)) {
+                $result = \__::concat($result, [$sourceValue]);
+            } else {
+                $resultValue = \__::get($result, $key);
+                $result = \__::set($result, $key, concatDeep(
+                    \__::isCollection($resultValue) ? $resultValue : (array) $resultValue,
+                    \__::isCollection($sourceValue) ? $sourceValue : (array) $sourceValue
+                ));
+            }
+        });
+        return $result;
+    }, []);
+}

--- a/src/__/collections/doForEachRight.php
+++ b/src/__/collections/doForEachRight.php
@@ -5,16 +5,27 @@ namespace collections;
 /**
  * Iterate an array or other foreach-able without making a copy of it.
  *
- * From mpen and linepogl https://stackoverflow.com/a/36605605/1956471
+ * Code for PHP_VERSION >= 5.5.(using `yiel`) is from mpen and linepogl
+ * See https://stackoverflow.com/a/36605605/1956471
  *
  * @param array|\Traversable $iterable
  * @return Generator
  */
-function iter_reverse($iterable) {
-    for (end($iterable); ($key = key($iterable)) !== null; prev($iterable)) {
-        yield $key => current($iterable);
-    }
-}
+ if (version_compare(PHP_VERSION, '5.5.0', '<')) {
+     eval('
+     function iter_reverse($iterable) {
+         return array_reverse($iterable);
+     }
+     ');
+ } else {
+     eval('
+     function iter_reverse($iterable) {
+         for (end($iterable); ($key = key($iterable)) !== null; prev($iterable)) {
+             yield $key => current($iterable);
+         }
+     }
+     ');
+ }
 
 /**
  * Iterate over elements of the collection, from right to left, and invokes iteratee

--- a/src/__/collections/doForEachRight.php
+++ b/src/__/collections/doForEachRight.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace collections;
+
+/**
+ * Iterate an array or other foreach-able without making a copy of it.
+ *
+ * From mpen and linepogl https://stackoverflow.com/a/36605605/1956471
+ *
+ * @param array|\Traversable $iterable
+ * @return Generator
+ */
+function iter_reverse($iterable) {
+    for (end($iterable); ($key = key($iterable)) !== null; prev($iterable)) {
+        yield $key => current($iterable);
+    }
+}
+
+/**
+ * Iterate over elements of the collection, from right to left, and invokes iteratee
+ * for each element.
+ *
+ * The iteratee is invoked with three arguments: (value, index|key, collection).
+ * Iteratee functions may exit iteration early by explicitly returning false.
+ *
+ ** __::doForEachRight([1, 2, 3], function ($value) { print_r($value) });
+ ** // → (Side effect: print 3, 2, 1)
+ *
+ * @param array|object $collection The collection to iterate over.
+ * @param Closure $iterate The function to call for each value.
+ *
+ * @return null
+ *
+ */
+function doForEachRight($collection, \Closure $iteratee)
+{
+    \__::doForEach(iter_reverse($collection), $iteratee);
+}

--- a/src/__/collections/doForEachRight.php
+++ b/src/__/collections/doForEachRight.php
@@ -14,7 +14,7 @@ namespace collections;
  if (version_compare(PHP_VERSION, '5.5.0', '<')) {
      eval('
      function iter_reverse($iterable) {
-         return array_reverse($iterable);
+         return array_reverse($iterable, true);
      }
      ');
  } else {

--- a/src/__/collections/has.php
+++ b/src/__/collections/has.php
@@ -26,9 +26,12 @@ function has($collection, $path)
     $key  = $portions[0];
 
     if (\count($portions) === 1) {
-        $has = \__::isObject($collection) ? 'property_exists' : 'array_key_exists';
-        $args = \__::isObject($collection) ? [$collection, $key] : [$key, $collection];
-        return call_user_func_array($has, $args);
+//         $has = \__::isObject($collection) ? 'property_exists' : 'array_key_exists';
+//         $args = \__::isObject($collection) ? [$collection, $key] : [$key, $collection];
+//         return call_user_func_array($has, $args);
+        // We use a cast to array to handle the numeric keys for objects (workaround).
+        // See: https://wiki.php.net/rfc/convert_numeric_keys_in_object_array_casts
+        return array_key_exists($key, (array) $collection);
     }
     return has(\__::get($collection, $key), $portions[1]);
 }

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -27,14 +27,7 @@ function merge()
             } else if(is_numeric($key)) {
                 array_push($result, $sourceValue);
             } else {
-                $resultValue = $result[$key];
-                if(!\__::isArray($resultValue)) {
-                    $resultValue = [$resultValue];
-                }
-                if(!\__::isArray($sourceValue)) {
-                    $sourceValue = [$sourceValue];
-                }
-                $result[$key] = merge($resultValue, $sourceValue);
+                $result[$key] = merge((array) $result[$key], (array) $sourceValue);
             }
         });
         return $result;

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -38,6 +38,4 @@ function merge()
         });
         return $result;
     }, []);
-    // PHP 5.6+ array_merge_recursive(...func_get_args());
-    // return call_user_func_array('array_merge_recursive', func_get_args());
 }

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -23,11 +23,20 @@ function merge()
     return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
         \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
             if (!\__::has($result, $key)) {
-                $result[$key] = $sourceValue;
+                $result = \__::set($result, $key, $sourceValue);
             } else if(is_numeric($key)) {
-                array_push($result, $sourceValue);
+                // We want to append to the collection. As we can't append using numerical keys
+                // on objects, we have to cast to arrays.
+                // TODO: use __::append
+                $resultArray = (array) $result;
+                array_push($resultArray, $sourceValue);
+                $result = \__::isObject($result) ? (object) $resultArray : $resultArray;
             } else {
-                $result[$key] = merge((array) $result[$key], (array) $sourceValue);
+                $resultValue = \__::get($result, $key);
+                $result = \__::set($result, $key, merge(
+                    \__::isCollection($resultValue) ? $resultValue : (array) $resultValue,
+                    \__::isCollection($sourceValue) ? $sourceValue : (array) $sourceValue
+                ));
             }
         });
         return $result;

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -18,31 +18,27 @@ namespace collections;
  * @return array|object Merged collection.
  *
  */
-function merge($collection1, $collection2)
+function merge()
 {
-    // TODO Reimplement array_merge_recursive with support for objects.
-    // __::merge() is an __:assign() with recursivity. Nop: index appending.
-    // $isObject = \__::isObject($collection1);
-    // return \__::reduce(func_get_args(), function ($merged, $collectionN) {
-    //     \__::doForEach($collectionN, function ($value, $key) use(&$merged) {
-    //         if (\__::has($merged, $key)) {
-    //             // Append the value.
-    //             if (!\__::isArray($merged[$key])) {
-    //                 $merged[$key] = [$merged[$key]];
-    //             }
-    //             $merged[$key][] = $value;
-    //             // TODO Where the recursivity?
-    //         } else {
-    //             $merged[$key] = $value;
-    //             // $merged = \__::assign($merged, [$key => $value]);
-    //         }
-    //     });
-    //     return $merged;
-    //     // return \__::assign($merged, $collectionN);
-    // }, []);
-    // foreach (func_get_args() as $collectionN) {
-    //
-    // }
+    return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
+        \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
+            if (!\__::has($result, $key)) {
+                $result[$key] = $sourceValue;
+            } else if(is_numeric($key)) {
+                array_push($result, $sourceValue);
+            } else {
+                $resultValue = $result[$key];
+                if(!\__::isArray($resultValue)) {
+                    $resultValue = [$resultValue];
+                }
+                if(!\__::isArray($sourceValue)) {
+                    $sourceValue = [$sourceValue];
+                }
+                $result[$key] = merge($resultValue, $sourceValue);
+            }
+        });
+        return $result;
+    }, []);
     // PHP 5.6+ array_merge_recursive(...func_get_args());
-    return call_user_func_array('array_merge_recursive', func_get_args());
+    // return call_user_func_array('array_merge_recursive', func_get_args());
 }

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -20,6 +20,8 @@ namespace collections;
  */
 function merge()
 {
+    // TODO Use __::reduceRight()
+    // (Requires to implement it. Itself may use __::doForEachRight() as base).
     return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
         \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
             if (!\__::has($result, $key)) {

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -20,6 +20,26 @@ namespace collections;
  */
 function merge($collection1, $collection2)
 {
+    // TODO Reimplement array_merge_recursive with support for objects.
+    // __::merge() is an __:assign() with recursivity. Nop: index appending.
+    // $isObject = \__::isObject($collection1);
+    // return \__::reduce(func_get_args(), function ($merged, $collectionN) {
+    //     \__::doForEach($collectionN, function ($value, $key) use(&$merged) {
+    //         if (\__::has($merged, $key)) {
+    //             // Append the value.
+    //             if (!\__::isArray($merged[$key])) {
+    //                 $merged[$key] = [$merged[$key]];
+    //             }
+    //             $merged[$key][] = $value;
+    //             // TODO Where the recursivity?
+    //         } else {
+    //             $merged[$key] = $value;
+    //             // $merged = \__::assign($merged, [$key => $value]);
+    //         }
+    //     });
+    //     return $merged;
+    //     // return \__::assign($merged, $collectionN);
+    // }, []);
     // foreach (func_get_args() as $collectionN) {
     //
     // }

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -21,9 +21,7 @@ namespace collections;
  */
 function merge()
 {
-    // TODO Use __::reduceRight()
-    // (Requires to implement it. Itself may use __::doForEachRight() as base).
-    return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
+    return \__::reduceRight(func_get_args(), function ($source, $result) {
         \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
             $value = $sourceValue;
             if (\__::isCollection($value)) {

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace collections;
+
+/**
+ * Recursively combines collections provided with each others. If the collections have
+ * common keys, then the values are appended in an array. If numerical indexes
+ * are passed, then values are appended.
+ *
+ * For a non-recursive merge, see __::assign.
+ *
+ ** __::merge(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
+ ** // >> ['color' => ['favorite' => ['red', 'green'], 'blue'], 5, 10]
+ *
+ * @param array|object $collection1 First collection to merge.
+ * @param array|object $... N other collections to merge.
+ *
+ * @return array|object Merged collection.
+ *
+ */
+function merge($collection1, $collection2)
+{
+    // foreach (func_get_args() as $collectionN) {
+    //
+    // }
+    // PHP 5.6+ array_merge_recursive(...func_get_args());
+    return call_user_func_array('array_merge_recursive', func_get_args());
+}

--- a/src/__/collections/merge.php
+++ b/src/__/collections/merge.php
@@ -3,19 +3,20 @@
 namespace collections;
 
 /**
- * Recursively combines collections provided with each others. If the collections have
- * common keys, then the values are appended in an array. If numerical indexes
- * are passed, then values are appended.
+ * Recursively combines and merge collections provided with each others.
  *
- * For a non-recursive merge, see __::assign.
+ * If the collections have common keys, then the last passed keys override the previous.
+ * If numerical indexes are passed, then last passed indexes override the previous.
  *
- ** __::merge(['color' => ['favorite' => 'red', 5]], [10, 'color' => ['favorite' => 'green', 'blue']]);
- ** // >> ['color' => ['favorite' => ['red', 'green'], 'blue'], 5, 10]
+ * For a non-recursive merge, see __::merge.
+ *
+ ** __::merge(['color' => ['favorite' => 'red', 'model' => 3, 5], 3], [10, 'color' => ['favorite' => 'green', 'blue']]);
+ ** // >> ['color' => ['favorite' => 'green', 'model' => 3, 'blue'], 10]
  *
  * @param array|object $collection1 First collection to merge.
  * @param array|object $... N other collections to merge.
  *
- * @return array|object Merged collection.
+ * @return array|object Concatened collection.
  *
  */
 function merge()
@@ -24,17 +25,11 @@ function merge()
     // (Requires to implement it. Itself may use __::doForEachRight() as base).
     return \__::reduce(array_reverse(func_get_args()), function ($source, $result) {
         \__::doForEach($source, function ($sourceValue, $key) use(&$result) {
-            if (!\__::has($result, $key)) {
-                $result = \__::set($result, $key, $sourceValue);
-            } else if(is_numeric($key)) {
-                $result = \__::assign($result, [$sourceValue]);
-            } else {
-                $resultValue = \__::get($result, $key);
-                $result = \__::set($result, $key, merge(
-                    \__::isCollection($resultValue) ? $resultValue : (array) $resultValue,
-                    \__::isCollection($sourceValue) ? $sourceValue : (array) $sourceValue
-                ));
+            $value = $sourceValue;
+            if (\__::isCollection($value)) {
+                $value = merge(\__::get($result, $key), $sourceValue);
             }
+            $result = \__::set($result, $key, $value);
         });
         return $result;
     }, []);

--- a/src/__/collections/reduceRight.php
+++ b/src/__/collections/reduceRight.php
@@ -27,7 +27,7 @@ namespace collections;
  */
 function reduceRight($collection, \Closure $iteratee, $accumulator = NULL)
 {
-    // TODO Factorize using iter_reverse: make it a function.
+    // TODO Factorize using iter_reverse: make it a function. (See doForEachRight)
     if ($accumulator === NULL) {
         $accumulator = \__::first($collection);
     }

--- a/src/__/collections/reduceRight.php
+++ b/src/__/collections/reduceRight.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace collections;
+
+/**
+ * Reduces $collection to a value which is the $accumulator result of running each
+ * element in $collection - from right to left - thru $iteratee, where each
+ * successive invocation is supplied the return value of the previous.
+ *
+ * If $accumulator is not given, the first element of $collection is used as the
+ * initial value.
+ *
+ * The $iteratee is invoked with four arguments:
+ * ($accumulator, $value, $index|$key, $collection).
+ *
+ ** __::reduceRight(['a', 'b', 'c'], function ($word, $char) {
+ **     return $word . $char;
+ ** }, '');
+ ** // >> 'cba'
+ *
+ * @param array|object $collection The collection to iterate over.
+ * @param \Closure $iteratee The function invoked per iteration.
+ * @param (*) [$accumulator] The initial value.
+ *
+ * @return (*): Returns the accumulated value.
+ *
+ */
+function reduceRight($collection, \Closure $iteratee, $accumulator = NULL)
+{
+    // TODO Factorize using iter_reverse: make it a function.
+    if ($accumulator === NULL) {
+        $accumulator = \__::first($collection);
+    }
+    \__::doForEachRight(
+        $collection,
+        function ($value, $key, $collection) use(&$accumulator, $iteratee) {
+            $accumulator = $iteratee($accumulator, $value, $key, $collection);
+        }
+    );
+    return $accumulator;
+}

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,7 +9,7 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [10]
- ** Collections                                  [27]
+ ** Collections                                  [28]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [2]
@@ -63,8 +63,9 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array min(array|\Traversable $input) Returns the minimum value from the collection. If passed an iterator, min will return min value returned by the iterator.
  * @method static array pluck(array|object $input, string $key) Returns an array of values belonging to a given property of each item in a collection.
  * @method static mixed reduce(array|\Traversable $input, \Closure $iteratee, mixed $accumulator = null) Reduces a collection to a value which is the $accumulator result of running each element in the collection thru $iteratee, where each successive invocation is supplied the return value of the previous.
+ * @method static mixed reduceRight(array|\Traversable $input, \Closure $iteratee, mixed $accumulator = null) Reduces a collection to a value which is the $accumulator result of running each element in the collection - from right to left - thru $iteratee, where each successive invocation is supplied the return value of the previous.
  * @method static array set(array|object $collection = [], string $key = '', $value = null, $strict = false) Set item of an array by index to given value, aceepting nested index
-* @method static array pick(array $array = [], array $paths = [], $default = null) Returns an array having only keys present in the given path list.
+ * @method static array pick(array $array = [], array $paths = [], $default = null) Returns an array having only keys present in the given path list.
  * @method static array unease(array $input, string $separator = '.')
  * @method static array where(array|\Traversable $input, mixed $itemParams = '')
  *

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,11 +9,11 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [10]
- ** Collections                                 [24]
+ ** Collections                                  [24]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [2]
- ** Strings                                     [13]
+ ** Strings                                      [13]
  ** Sequences                                    [1]
 
  ***************************************************

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,7 +9,7 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [10]
- ** Collections                                  [26]
+ ** Collections                                  [27]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [2]
@@ -47,6 +47,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array filter(array|\Traversable $input, \Closure $func = null) Returns the values in the collection that pass the truth test.
  * @method static array|mixed first(array $input, int $count = null) Gets the first element of an array. Passing n returns the first n elements.
  * @method static null doForEach(array|object $collection, \Closure $iteratee) Iterate over elements of the collection and invokes iteratee for each element.
+ * @method static null doForEachRight(array|object $collection, \Closure $iteratee) Iterate over elements of the collection, from right to left, and invokes iteratee for each element.
  * @method static bool every(array|object $collection, \Closure $iteratee) Checks if predicate returns truthy for all elements of collection.
  * @method static array|mixed get(array|object $collection, string $path, \Closure|mixed $default = null)
  * @method static array groupBy(array $input, int|float|string|\Closure $key) Returns an associative array where the keys are values of $key.

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,7 +9,7 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [10]
- ** Collections                                  [24]
+ ** Collections                                  [26]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [2]
@@ -40,7 +40,9 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array range(int $startOrCount, int $stop = null, int $step = null) Returns an array of integers from start to stop (exclusive) by step.
  * @method static array repeat($input, int $times = 0) Returns an array of input repeated $times times.
  *
- * @method static array|object assign(array|object $collection1, [array|object $... ]) Combines collections provided with each others.
+ * @method static array|object assign(array|object $collection1, [array|object $... ]) Combines and merge collections provided with each others.
+ * @method static array|object concat(array|object $collection1, [array|object $... ]) Combines and concat collections provided with each others.
+ * @method static array|object concatDeep(array|object $collection1, [array|object $... ]) Recursively combines and concat collections provided with each others.
  * @method static array ease(array $input, string $glue = '.')
  * @method static array filter(array|\Traversable $input, \Closure $func = null) Returns the values in the collection that pass the truth test.
  * @method static array|mixed first(array $input, int $count = null) Gets the first element of an array. Passing n returns the first n elements.
@@ -56,7 +58,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array mapKeys(array $input, \Closure $func = null) Returns an array with keys being mapped through the iterator
  * @method static array mapValues(array $input, \Closure $func = null) Returns an array with values being mapped through the iterator
  * @method static array max(array|\Traversable $input) Returns the maximum value from the collection. If passed an iterator, max will return max value returned by the iterator.
- * @method static array|object merge(array|object $collection1, [array|object $... ]) Recursively combines collections provided with each others.
+ * @method static array|object concatDeep(array|object $collection1, [array|object $... ]) Recursively combines collections provided with each others.
  * @method static array min(array|\Traversable $input) Returns the minimum value from the collection. If passed an iterator, min will return min value returned by the iterator.
  * @method static array pluck(array|object $input, string $key) Returns an array of values belonging to a given property of each item in a collection.
  * @method static mixed reduce(array|\Traversable $input, \Closure $iteratee, mixed $accumulator = null) Reduces a collection to a value which is the $accumulator result of running each element in the collection thru $iteratee, where each successive invocation is supplied the return value of the previous.

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -9,7 +9,7 @@ namespace __;
  ***************************************************
 
  ** Arrays                                       [10]
- ** Collections                                 [22]
+ ** Collections                                 [24]
  ** Functions                                    [3]
  ** Objects                                      [8]
  ** Utilities                                    [2]
@@ -40,6 +40,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array range(int $startOrCount, int $stop = null, int $step = null) Returns an array of integers from start to stop (exclusive) by step.
  * @method static array repeat($input, int $times = 0) Returns an array of input repeated $times times.
  *
+ * @method static array|object assign(array|object $collection1, [array|object $... ]) Combines collections provided with each others.
  * @method static array ease(array $input, string $glue = '.')
  * @method static array filter(array|\Traversable $input, \Closure $func = null) Returns the values in the collection that pass the truth test.
  * @method static array|mixed first(array $input, int $count = null) Gets the first element of an array. Passing n returns the first n elements.
@@ -55,6 +56,7 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  * @method static array mapKeys(array $input, \Closure $func = null) Returns an array with keys being mapped through the iterator
  * @method static array mapValues(array $input, \Closure $func = null) Returns an array with values being mapped through the iterator
  * @method static array max(array|\Traversable $input) Returns the maximum value from the collection. If passed an iterator, max will return max value returned by the iterator.
+ * @method static array|object merge(array|object $collection1, [array|object $... ]) Recursively combines collections provided with each others.
  * @method static array min(array|\Traversable $input) Returns the minimum value from the collection. If passed an iterator, min will return min value returned by the iterator.
  * @method static array pluck(array|object $input, string $key) Returns an array of values belonging to a given property of each item in a collection.
  * @method static mixed reduce(array|\Traversable $input, \Closure $iteratee, mixed $accumulator = null) Reduces a collection to a value which is the $accumulator result of running each element in the collection thru $iteratee, where each successive invocation is supplied the return value of the previous.

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -3,6 +3,41 @@
 class CollectionsTest extends \PHPUnit\Framework\TestCase
 {
     // ...
+    public function testAssign()
+    {
+        // Arrange
+        $a1 = ['color' => ['favorite' => 'red', 5]];
+        $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
+        $b1 = ['a' => 0];
+        $b2 = ['a' => 1, 'b' => 2];
+        $b3 = ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::assign($a1, $a2);
+        $y = __::assign($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals(['color' => ['favorite' => 'green', 'blue'], 10], $x);
+        $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
+
+    public function testAssignObject()
+    {
+        // Arrange
+        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
+        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+        $b1 = (object) ['a' => 0];
+        $b2 = (object) ['a' => 1, 'b' => 2];
+        $b3 = (object) ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::assign($a1, $a2);
+        $y = __::assign($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals((object) ['color' => (object) ['favorite' => 'green', 'blue'], 10], $x);
+        $this->assertEquals((object) ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
 
     public function testEase()
     {
@@ -411,6 +446,42 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         // Assert
         $this->assertEquals(3, $x);
+    }
+
+    public function testMerge()
+    {
+        // Arrange
+        $a1 = ['color' => ['favorite' => 'red', 5]];
+        $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
+        $b1 = ['a' => 0];
+        $b2 = ['a' => 1, 'b' => 2];
+        $b3 = ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::merge($a1, $a2);
+        $y = __::merge($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals(['color' => ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
+        $this->assertEquals(['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
+
+    public function testMergeObject()
+    {
+        // Arrange
+        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
+        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+        $b1 = (object) ['a' => 0];
+        $b2 = (object) ['a' => 1, 'b' => 2];
+        $b3 = (object) ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::merge($a1, $a2);
+        $y = __::merge($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
+        $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
     }
 
 

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -312,6 +312,8 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $a = ['foo' => 'bar'];
         $b = (object) ['foo' => 'bar'];
         $c = ['foo' => ['bar' => 'foie']];
+        $d = [5];
+        $e = (object) [5];
 
         // Act.
         $x = __::has($a, 'foo');
@@ -319,6 +321,8 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $z = __::has($b, 'foo');
         $xa = __::has($b, 'foz');
         $xb = __::has($c, 'foo.bar');
+        $xc = __::has($d, 0);
+        $xd = __::has($e, 0);
 
         // Assert.
         $this->assertTrue($x);
@@ -326,6 +330,8 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($z);
         $this->assertFalse($xa);
         $this->assertTrue($xb);
+        $this->assertTrue($xc);
+        $this->assertTrue($xd);
     }
 
     public function testHasKeys()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -3,10 +3,11 @@
 class CollectionsTest extends \PHPUnit\Framework\TestCase
 {
     // ...
+
     public function testAssign()
     {
         // Arrange
-        $a1 = ['color' => ['favorite' => 'red', 5]];
+        $a1 = ['color' => ['favorite' => 'red', 'model' => 3, 5], 3];
         $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
         $b1 = ['a' => 0];
         $b2 = ['a' => 1, 'b' => 2];
@@ -27,8 +28,8 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
         $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
         $b1 = (object) ['a' => 0];
-        $b2 = (object) ['a' => 1, 'b' => 2];
-        $b3 = (object) ['c' => 3, 'd' => 4];
+        $b2 = (object) ['a' => 1, 'b' => 2, 5];
+        $b3 = (object) ['c' => 3, 'd' => 4, 6];
 
         // Act
         $x = __::assign($a1, $a2);
@@ -36,7 +37,83 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         // Assert
         $this->assertEquals((object) ['color' => (object) ['favorite' => 'green', 'blue'], 10], $x);
+        $this->assertEquals((object) ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 6], $y);
+    }
+
+    public function testConcat()
+    {
+        // Arrange
+        $a1 = ['color' => ['favorite' => 'red', 5], 3];
+        $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
+        $b1 = ['a' => 0];
+        $b2 = ['a' => 1, 'b' => 2, 5];
+        $b3 = ['c' => 3, 'd' => 4, 6];
+        $c1 = [1, 2, 3];
+        $c2 = [4, 5];
+
+        // Act
+        $x = __::concat($a1, $a2);
+        $y = __::concat($b1, $b2, $b3);
+        $z = __::concat($c1, $c2);
+
+        // Assert
+        $this->assertEquals(['color' => ['favorite' => 'green', 'blue'], 3, 10], $x);
+        $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 5, 6], $y);
+        $this->assertEquals([1, 2, 3, 4, 5], $z);
+    }
+
+    public function testConcatObject()
+    {
+        // Arrange
+        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
+        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+        $b1 = (object) ['a' => 0];
+        $b2 = (object) ['a' => 1, 'b' => 2];
+        $b3 = (object) ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::concat($a1, $a2);
+        $y = __::concat($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals((object) ['color' => (object) ['favorite' => 'green', 'blue'], 10], $x);
         $this->assertEquals((object) ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
+
+    public function testConcatDeep()
+    {
+        // Arrange
+        $a1 = ['color' => ['favorite' => 'red', 5], 3];
+        $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
+        $b1 = ['a' => 0];
+        $b2 = ['a' => 1, 'b' => 2];
+        $b3 = ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::concatDeep($a1, $a2);
+        $y = __::concatDeep($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals(['color' => ['favorite' => ['red', 'green'], 5, 'blue'], 3, 10], $x);
+        $this->assertEquals(['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
+
+    public function testConcatDeepObject()
+    {
+        // Arrange
+        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
+        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+        $b1 = (object) ['a' => 0];
+        $b2 = (object) ['a' => 1, 'b' => 2];
+        $b3 = (object) ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::concatDeep($a1, $a2);
+        $y = __::concatDeep($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
+        $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
     }
 
     public function testEase()
@@ -454,43 +531,6 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(3, $x);
     }
 
-    public function testMerge()
-    {
-        // Arrange
-        $a1 = ['color' => ['favorite' => 'red', 5]];
-        $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
-        $b1 = ['a' => 0];
-        $b2 = ['a' => 1, 'b' => 2];
-        $b3 = ['c' => 3, 'd' => 4];
-
-        // Act
-        $x = __::merge($a1, $a2);
-        $y = __::merge($b1, $b2, $b3);
-
-        // Assert
-        $this->assertEquals(['color' => ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
-        $this->assertEquals(['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
-    }
-
-    public function testMergeObject()
-    {
-        // Arrange
-        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
-        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
-        $b1 = (object) ['a' => 0];
-        $b2 = (object) ['a' => 1, 'b' => 2];
-        $b3 = (object) ['c' => 3, 'd' => 4];
-    
-        // Act
-        $x = __::merge($a1, $a2);
-        $y = __::merge($b1, $b2, $b3);
-    
-        // Assert
-        $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
-        $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
-    }
-
-
     public function testMin()
     {
         // Arrange
@@ -501,6 +541,42 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
 
         // Assert
         $this->assertEquals(1, $x);
+    }
+
+    public function testMerge()
+    {
+        // Arrange
+        $a1 = ['color' => ['favorite' => 'red', 'model' => 3, 5], 3];
+        $a2 = [10, 'color' => ['favorite' => 'green', 'blue']];
+        $b1 = ['a' => 0];
+        $b2 = ['a' => 1, 'b' => 2];
+        $b3 = ['c' => 3, 'd' => 4];
+
+        // Act
+        $x = __::merge($a1, $a2);
+        $y = __::merge($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals(['color' => ['favorite' => 'green', 'model' => 3, 'blue'], 10], $x);
+        $this->assertEquals(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
+
+    public function testMergeObject()
+    {
+        // Arrange
+        $a1 = (object) ['color' => (object) ['favorite' => 'red', 'model' => 3, 5]];
+        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+        $b1 = (object) ['a' => 0];
+        $b2 = (object) ['a' => 1, 'b' => 2, 5];
+        $b3 = (object) ['c' => 3, 'd' => 4, 6];
+
+        // Act
+        $x = __::merge($a1, $a2);
+        $y = __::merge($b1, $b2, $b3);
+
+        // Assert
+        $this->assertEquals((object) ['color' => (object) ['favorite' => 'green', 'model' => 3, 'blue'], 10], $x);
+        $this->assertEquals((object) ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 6], $y);
     }
 
     public function testPluck()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -206,6 +206,36 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($b, $bMapped);
     }
 
+    public function testDoForEachRight()
+    {
+        // Arrange
+        $makeAppend = function (&$array) {
+            return function ($value) use(&$array) {
+                $array[] = $value;
+            };
+        };
+        $makeMapper = function (&$array) {
+            return function ($value, $key) use(&$array) {
+                $array[$key] = $value;
+            };
+        };
+        $a = [1, 2, 3];
+        $b = ['state' => 'IN', 'city' => 'Indianapolis', 'object' => 'School bus'];
+
+        // Act.
+        $aAppend = [];
+        $aMapped = [];
+        $bMapped = [];
+        __::doForEachRight($a, $makeAppend($aAppend));
+        __::doForEachRight($a, $makeMapper($aMapped));
+        __::doForEachRight($b, $makeMapper($bMapped));
+
+        // Assert
+        $this->assertEquals(array_reverse($a), $aAppend);
+        $this->assertEquals($a, $aMapped);
+        $this->assertEquals($b, $bMapped);
+    }
+
     public function testEvery()
     {
         // Arrange.

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -752,6 +752,21 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         ], $y);
     }
 
+    public function testReduceRightArray()
+    {
+        // Arrange
+        $a = ['a', 'b', 'c'];
+        $aReducer = function ($word, $char) {
+            return $word . $char;
+        };
+
+        // Act
+        $x = __::reduceRight($a, $aReducer, '');
+
+        // Assert
+        $this->assertEquals('cba', $x);
+    }
+
     public function testPick()
     {
         // Arrange

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -472,23 +472,23 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
     }
 
-    // public function testMergeObject()
-    // {
-    //     // Arrange
-    //     $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
-    //     $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
-    //     $b1 = (object) ['a' => 0];
-    //     $b2 = (object) ['a' => 1, 'b' => 2];
-    //     $b3 = (object) ['c' => 3, 'd' => 4];
-    //
-    //     // Act
-    //     $x = __::merge($a1, $a2);
-    //     $y = __::merge($b1, $b2, $b3);
-    //
-    //     // Assert
-    //     $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
-    //     $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
-    // }
+    public function testMergeObject()
+    {
+        // Arrange
+        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
+        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+        $b1 = (object) ['a' => 0];
+        $b2 = (object) ['a' => 1, 'b' => 2];
+        $b3 = (object) ['c' => 3, 'd' => 4];
+    
+        // Act
+        $x = __::merge($a1, $a2);
+        $y = __::merge($b1, $b2, $b3);
+    
+        // Assert
+        $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
+        $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    }
 
 
     public function testMin()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -466,23 +466,23 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
     }
 
-    public function testMergeObject()
-    {
-        // Arrange
-        $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
-        $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
-        $b1 = (object) ['a' => 0];
-        $b2 = (object) ['a' => 1, 'b' => 2];
-        $b3 = (object) ['c' => 3, 'd' => 4];
-
-        // Act
-        $x = __::merge($a1, $a2);
-        $y = __::merge($b1, $b2, $b3);
-
-        // Assert
-        $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
-        $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
-    }
+    // public function testMergeObject()
+    // {
+    //     // Arrange
+    //     $a1 = (object) ['color' => (object) ['favorite' => 'red', 5]];
+    //     $a2 = (object) [10, 'color' => (object) ['favorite' => 'green', 'blue']];
+    //     $b1 = (object) ['a' => 0];
+    //     $b2 = (object) ['a' => 1, 'b' => 2];
+    //     $b3 = (object) ['c' => 3, 'd' => 4];
+    //
+    //     // Act
+    //     $x = __::merge($a1, $a2);
+    //     $y = __::merge($b1, $b2, $b3);
+    //
+    //     // Assert
+    //     $this->assertEquals((object) ['color' => (object) ['favorite' => ['red', 'green'], 5, 'blue'], 10], $x);
+    //     $this->assertEquals((object) ['a' => [0, 1], 'b' => 2, 'c' => 3, 'd' => 4], $y);
+    // }
 
 
     public function testMin()


### PR DESCRIPTION
Add `__::assign()` and `__::merge()` for merging collections.

What is missing: implementing a `__::merge()` working on both arrays and objects. See [test cases](https://github.com/YtoTech/bottomline/blob/cb63883f12c3d55066b550f99dda25f0c04c03f3/tests/collections.php#L469).
We may continue to use [`array_merge_recursive`](http://php.net/manual/fr/function.array-merge-recursive.php) as base, but we will have to handle recursive casting - casting input as arrays for `array_merge_recursive` support and output as objects (when input was object).