### PR TITLE
Add support for ArrayAccess in get() + set()

### DIFF
--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -25,7 +25,7 @@ function get($collection, $path, $default = null)
     }
 
     foreach (\__::split($path, '.') as $segment) {
-        if (\is_object($collection)) {
+        if (\is_object($collection) && !($collection instanceof \ArrayAccess)) {
             if (isset($collection->{$segment})) {
                 $collection = $collection->{$segment};
             } else {

--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -5,6 +5,9 @@ namespace collections;
 /**
  * get item of an array by index, accepting path (nested index).
  *
+ * If $collection is an object that implementes the ArrayAccess interface, this
+ * function will treat it as an array instead of accessing class properties.
+ *
  ** __::get(['foo' => ['bar' => 'ter']], 'foo.bar');
  ** // → 'ter'
  *

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -22,6 +22,9 @@ function _universal_set($collection, $key, $value) {
  * Return a new collection with the item set at index to given value.
  * Index can be a path of nested indexes.
  *
+ * If $collection is an object that implements the ArrayAccess interface, this
+ * function will treat it as an array.
+ *
  * If a portion of path doesn't exist, it's created. Arrays are created for missing
  * index in an array; objects are created for missing property in an object.
  *
@@ -59,7 +62,7 @@ function set($collection, $path, $value = null)
         || (\__::isObject($collection) && !\__::isObject(\__::get($collection, $key)))
         || (\__::isArray($collection) && !\__::isArray(\__::get($collection, $key)))
     ) {
-        $collection = _universal_set($collection, $key, \__::isObject($collection) ? new \stdClass : []);
+        $collection = _universal_set($collection, $key, (\__::isObject($collection) && !($collection instanceof \ArrayAccess)) ? new \stdClass : []);
     }
     return _universal_set($collection, $key, set(\__::get($collection, $key), $portions[1], $value));
 }

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -14,7 +14,7 @@ function _universal_set($collection, $key, $value) {
         $array[$key] = $value;
         return $array;
     };
-    $setter = \__::isObject($collection) ? $set_object : $set_array;
+    $setter = \__::isObject($collection) && !($collection instanceof \ArrayAccess) ? $set_object : $set_array;
     return call_user_func_array($setter, [$collection, $key, $value]);
 }
 

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -1,5 +1,30 @@
 <?php
 
+class ArrayAccessible implements ArrayAccess
+{
+    private $content;
+
+    public function offsetExists($offset)
+    {
+        return isset($this->content[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->content[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->content[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->content[$offset]);
+    }
+}
+
 class CollectionsTest extends \PHPUnit\Framework\TestCase
 {
     // ...
@@ -303,6 +328,23 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('default', $y2);
         $this->assertEquals('default_from_callback', $y3);
         $this->assertEquals($o, $z);
+    }
+
+    public function testGetArrayAccess()
+    {
+        $aa = new ArrayAccessible();
+        $aa['foo'] = [
+            'bar' => 'quim',
+        ];
+        $aa['bar'] = 5;
+        $aa['caz'] = new \stdClass();
+        $aa['caz']->daer = 'heft';
+
+        $this->assertEquals('quim', __::get($aa, 'foo.bar'));
+        $this->assertEquals(5, __::get($aa, 'bar'));
+        $this->assertEquals('heft', __::get($aa, 'caz.daer'));
+
+        $this->assertNull(__::get($aa, 'foo.cat'));
     }
 
     public function testGetObjects()
@@ -839,6 +881,23 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(['foo' => ['bar' => 'ter']], $a);
         $this->assertEquals(['ber' => 'fer'], $x['foo']['baz']);
         $this->assertEquals(['foo' => ['bar' => 'fer2']], $y);
+    }
+
+    public function testSetArrayAccess()
+    {
+        $aa = new ArrayAccessible();
+
+        __::set($aa, 'foo.ubi', [
+            'bar' => 'qaz',
+        ]);
+        __::set($aa, 'faa.raot.uft', 100);
+
+        $this->assertTrue(is_object(__::get($aa, 'foo')));
+        $this->assertTrue(is_object(__::get($aa, 'faa')));
+        $this->assertTrue(is_object(__::get($aa, 'faa.raot')));
+
+        $this->assertEquals('qaz', __::get($aa, 'foo.ubi.bar'));
+        $this->assertEquals(42, __::get($aa, 'foo.nonexistent', 42));
     }
 
     public function testSetObject()

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -892,9 +892,9 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         ]);
         __::set($aa, 'faa.raot.uft', 100);
 
-        $this->assertTrue(is_object(__::get($aa, 'foo')));
-        $this->assertTrue(is_object(__::get($aa, 'faa')));
-        $this->assertTrue(is_object(__::get($aa, 'faa.raot')));
+        $this->assertTrue(is_array(__::get($aa, 'foo')));
+        $this->assertTrue(is_array(__::get($aa, 'faa')));
+        $this->assertTrue(is_array(__::get($aa, 'faa.raot')));
 
         $this->assertEquals('qaz', __::get($aa, 'foo.ubi.bar'));
         $this->assertEquals(42, __::get($aa, 'foo.nonexistent', 42));


### PR DESCRIPTION
For objects implementing `ArrayAccess`, their values should be gotten and set as if they are arrays.

Closes #40 