### PR TITLE
Add dot notation support to groupBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `__::doForEachRight`
 * Added `__::reduceRight`
 * Made `__::get` and `__::set` work as array getter and setter for objects implementing the ArrayAccess interface
+* Added dot notation support to `__::groupBy()`; it now uses `__::get()` and `__::set()` internally
 
 ## <sub>v0.1.1</sub>
 #### _Jan 12, 2018_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.0...0.1.1) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.1/README.md)

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ __::get(['foo' => ['bar' => 'ter']], 'foo.bar');
 ```
 
 ##### [__::groupBy](src/__/collections/groupBy.php)
-Group an array of objects or arrays based on a given key.
+Group an array of objects or arrays based on a given key, accepting a nested index (same as `__::get()`)
 ```php
 $a = [
     ['name' => 'maciej',    'continent' => 'Europe'],

--- a/src/__/collections/groupBy.php
+++ b/src/__/collections/groupBy.php
@@ -27,6 +27,36 @@ namespace collections;
  *
  *
  ** __::groupBy([
+ **         ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+ **         ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+ **         ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
+ **         ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
+ **         ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
+ **     ],
+ **     'metadata.state'
+ ** );
+ ** // >> [
+ ** //   'IN' => [
+ ** //     'Indianapolis' => [
+ ** //       ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+ ** //       ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+ ** //     ],
+ ** //     'Plainfield' => [
+ ** //       ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
+ ** //     ],
+ ** //   ],
+ ** //   'CA' => [
+ ** //     'San Diego' => [
+ ** //       ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
+ ** //     ],
+ ** //     'Mountain View' => [
+ ** //       ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
+ ** //     ],
+ ** //   ],
+ ** // ]
+ *
+ *
+ ** __::groupBy([
  **         ['state' => 'IN', 'city' => 'Indianapolis', 'object' => 'School bus'],
  **         ['state' => 'IN', 'city' => 'Indianapolis', 'object' => 'Manhole'],
  **         ['state' => 'CA', 'city' => 'San Diego', 'object' => 'Light bulb'],
@@ -63,10 +93,8 @@ function groupBy(array $array, $key)
 
         if (\is_callable($key)) {
             $groupKey = call_user_func($key, $value);
-        } elseif (\is_object($value) && \property_exists($value, $key)) {
-            $groupKey = $value->{$key};
-        } elseif (\is_array($value) && isset($value[$key])) {
-            $groupKey = $value[$key];
+        } else {
+            $groupKey = \__::get($value, $key);
         }
 
         if ($groupKey === null) {

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -392,7 +392,7 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('CA', $grouped);
     }
 
-    public function testGroupByStringNested()
+    public function testGroupByStringMultipleGroupings()
     {
         $a = [
             ['state' => 'IN', 'city' => 'Indianapolis', 'object' => 'School bus'],
@@ -406,6 +406,62 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(2, $grouped);
         $this->assertCount(2, $grouped['IN']);
         $this->assertArrayHasKey('Indianapolis', $grouped['IN']);
+    }
+
+    public function testGroupByNestedValues()
+    {
+        $a = [
+            ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+            ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+            ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
+            ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
+            ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
+        ];
+
+        $grouped = __::groupBy($a, 'metadata.state');
+        $this->assertEquals([
+            'IN' => [
+                ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+                ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+                ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
+            ],
+            'CA' => [
+                ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
+                ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
+            ],
+        ], $grouped);
+    }
+
+    public function testGroupByNestedValuesMultipleGrouping()
+    {
+        $a = [
+            ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+            ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+            ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
+            ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
+            ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
+        ];
+
+        $grouped = __::groupBy($a, 'metadata.state', 'metadata.city');
+        $this->assertEquals([
+            'IN' => [
+                'Indianapolis' => [
+                    ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+                    ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
+                ],
+                'Plainfield' => [
+                    ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
+                ],
+            ],
+            'CA' => [
+                'San Diego' => [
+                    ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
+                ],
+                'Mountain View' => [
+                    ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
+                ],
+            ],
+        ], $grouped);
     }
 
     public function testGroupByInteger()


### PR DESCRIPTION
Allow `__::groupBy()` to group by nested values in multidimensional arrays using the dot notation that `__::get()` and `__::set()` have available.

```php
$a = [
    ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
    ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
    ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
    ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
    ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
];

$grouped = __::groupBy($a, 'metadata.state');

// [
//     'IN' => [
//         ['object' => 'School bus', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
//         ['object' => 'Manhole', 'metadata' => ['state' => 'IN', 'city' => 'Indianapolis']],
//         ['object' => 'Basketball', 'metadata' => ['state' => 'IN', 'city' => 'Plainfield']],
//     ],
//     'CA' => [
//         ['object' => 'Light bulb', 'metadata' => ['state' => 'CA', 'city' => 'San Diego']],
//         ['object' => 'Space pen', 'metadata' => ['state' => 'CA', 'city' => 'Mountain View']],
//     ],
// ]
```