### PR TITLE
Add support for ArrayAccess to __::has()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `__::doForEachRight`
 * Added `__::reduceRight`
 * Made `__::get` and `__::set` work as array getter and setter for objects implementing the ArrayAccess interface
+* Made `__::has` call `offsetExists()` for objects implementing the ArrayAccess interface
 
 ## <sub>v0.1.1</sub>
 #### _Jan 12, 2018_ — [Diff](https://github.com/maciejczyzewski/bottomline/compare/0.1.0...0.1.1) — [Docs](https://github.com/maciejczyzewski/bottomline/blob/0.1.1/README.md)

--- a/src/__/collections/get.php
+++ b/src/__/collections/get.php
@@ -27,7 +27,7 @@ function get($collection, $path, $default = null)
         return $collection[$path];
     }
 
-    foreach (\__::split($path, '.') as $segment) {
+    foreach (\__::split($path, \__::DOT_NOTATION_DELIMITER) as $segment) {
         if (\is_object($collection) && !($collection instanceof \ArrayAccess)) {
             if (isset($collection->{$segment})) {
                 $collection = $collection->{$segment};

--- a/src/__/collections/has.php
+++ b/src/__/collections/has.php
@@ -5,7 +5,7 @@ namespace collections;
 /**
  * Return true if $collection contains the requested $key.
  *
- * In constrast to isset(), __::has() returns true if the key exists but is null.
+ * In contrast to isset(), __::has() returns true if the key exists but is null.
  *
  ** __::has(['foo' => ['bar' => 'num'], 'foz' => 'baz'], 'foo.bar');
  ** // → true
@@ -26,9 +26,12 @@ function has($collection, $path)
     $key  = $portions[0];
 
     if (\count($portions) === 1) {
-//         $has = \__::isObject($collection) ? 'property_exists' : 'array_key_exists';
-//         $args = \__::isObject($collection) ? [$collection, $key] : [$key, $collection];
-//         return call_user_func_array($has, $args);
+        // Calling array_key_exists on an ArrayAccess object will not call `offsetExists()`
+        // See: http://php.net/manual/en/class.arrayaccess.php#104061
+        if ($collection instanceof \ArrayAccess) {
+            return $collection->offsetExists($key);
+        }
+
         // We use a cast to array to handle the numeric keys for objects (workaround).
         // See: https://wiki.php.net/rfc/convert_numeric_keys_in_object_array_casts
         return array_key_exists($key, (array) $collection);

--- a/src/__/collections/has.php
+++ b/src/__/collections/has.php
@@ -21,8 +21,7 @@ namespace collections;
  */
 function has($collection, $path)
 {
-    // TODO Factorize path mavigation/enumeration with set and get.
-    $portions = \__::split($path, '.', 2);
+    $portions = \__::split($path, \__::DOT_NOTATION_DELIMITER, 2);
     $key  = $portions[0];
 
     if (\count($portions) === 1) {

--- a/src/__/collections/set.php
+++ b/src/__/collections/set.php
@@ -45,7 +45,7 @@ function set($collection, $path, $value = null)
         return $collection;
     }
 
-    $portions = \__::split($path, '.', 2);
+    $portions = \__::split($path, \__::DOT_NOTATION_DELIMITER, 2);
     $key  = $portions[0];
 
     if (\count($portions) === 1) {

--- a/src/__/load.php
+++ b/src/__/load.php
@@ -103,6 +103,8 @@ if (\version_compare(PHP_VERSION, '5.4.0', '<')) {
  */
 class __
 {
+    const DOT_NOTATION_DELIMITER = '.';
+
     private static $modules = [
         'arrays',
         'collections',

--- a/tests/collections.php
+++ b/tests/collections.php
@@ -2,11 +2,11 @@
 
 class ArrayAccessible implements ArrayAccess
 {
-    private $content;
+    private $content = [];
 
     public function offsetExists($offset)
     {
-        return isset($this->content[$offset]);
+        return array_key_exists($offset, $this->content);
     }
 
     public function offsetGet($offset)
@@ -481,6 +481,17 @@ class CollectionsTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($xb);
         $this->assertTrue($xc);
         $this->assertTrue($xd);
+    }
+
+    public function testHasArrayAccess()
+    {
+        $aa = new ArrayAccessible();
+        $aa['qux'] = true;
+        $aa['field'] = null;
+
+        $this->assertTrue(__::has($aa, 'qux'));
+        $this->assertTrue(__::has($aa, 'field'));
+        $this->assertFalse(__::has($aa, 'non-existent'));
     }
 
     public function testHasKeys()


### PR DESCRIPTION
Similar to the reasoning behind #41, `__::has()` should call `offsetExists()` for any objects that implement the ArrayAccess interface.